### PR TITLE
Cranelift: add Aug 1 meeting.

### DIFF
--- a/cranelift/2022/cranelift-08-01.md
+++ b/cranelift/2022/cranelift-08-01.md
@@ -1,0 +1,20 @@
+# August 1 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes


### PR DESCRIPTION
During today's biweekly we found that we hit the end of the timeslot and
still had items to discuss (including our usual status updates); we
agreed to overflow to the following week at least for now, and possibly
more in the future since our timeslot is a bit shorter now for many of
us.