### PR TITLE
Add Cranelift 2022-08-15 agenda, with Winch baseline compiler.

### DIFF
--- a/cranelift/2022/cranelift-08-15.md
+++ b/cranelift/2022/cranelift-08-15.md
@@ -1,0 +1,21 @@
+# August 15 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. ["Winch" baseline compiler](https://github.com/bytecodealliance/rfcs/pull/28): factoring/sharing of Cranelift's machine-code layer
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes


### PR DESCRIPTION
The meeting today (2022-08-08) had Winch on the agenda but we ran out of
time; so let's discuss it next week.