### PR TITLE
Add points for 08-31 (carry over from 08-15)

### DIFF
--- a/cranelift/2022/cranelift-08-31.md
+++ b/cranelift/2022/cranelift-08-31.md
@@ -11,6 +11,7 @@
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
+    1. ["Winch" baseline compiler](https://github.com/bytecodealliance/rfcs/pull/28): factoring/sharing of Cranelift's machine-code layer
     1. _Submit a PR to add your item here_
 
 ## Notes


### PR DESCRIPTION
Carry over agenda items from https://github.com/bytecodealliance/meetings/pull/14; the meeting on 08-15 was cancelled due to holidays. 

cc/ @cfallin 