### PR TITLE
Add a weekly component model implementation meeting

### DIFF
--- a/component-model/README.md
+++ b/component-model/README.md
@@ -1,0 +1,29 @@
+# Component Model Implementation Meetings
+
+The Bytecode Alliance hosts weekly meetings as status updates on the
+implementation of the component model in the ecosystem and in Wasmtime. Anyone
+interested in this is welcome to join.
+
+## Time and location
+
+**When**: every Friday at 11am PST
+**Where**: Zoom (link in calendar invite)
+
+## Attending
+
+To attend, please email <acrichton@fastly.com>, or reach out [on Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime).
+
+## Agendas and notes
+
+Unlike other meetings the Bytecode Alliance hosts this meeting does not have a
+prior agenda and does not retain notes at this time. It's intended to be
+informational and used for coordination around efforts on projects such as:
+
+* Wasmtime's component model implementation.
+* The `wit-bindgen` repository and language bindings.
+* Tooling such as `cargo component` and integration into language ecosystems.
+
+For now this is intended to be a "light weight" meeting in the sense that those
+who are interested can join and can feel free to drop out or not come at all if
+they're otherwise busy. It's unlikely that this meeting will take the full hour
+each week.


### PR DESCRIPTION
Some colleagues and I at Fastly have already been meeting at this time
to discuss details about the implementation of the component model in
addition to using it as a coordination point amongst us to ensure we are
all kept up-to-date with what's going on. At the last meeting we thought
it would be good to invite anyone else who's interested in this to also
drop in if they'd like.

Note that this meeting is not about the design of the component model
itself, that's best left for the WASI subgroup meetings. This is only
intended to be for the implementation of the component model as-proposed
and the tooling around it that the Bytecode Alliance is hosting.