### PR TITLE
Make Cranelift meetings weekly now (and add agendas).

### DIFF
--- a/cranelift/2022/cranelift-10-05.md
+++ b/cranelift/2022/cranelift-10-05.md
@@ -1,0 +1,20 @@
+# October 5 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/cranelift/2022/cranelift-10-19.md
+++ b/cranelift/2022/cranelift-10-19.md
@@ -1,0 +1,20 @@
+# October 19 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/cranelift/2022/cranelift-11-02.md
+++ b/cranelift/2022/cranelift-11-02.md
@@ -1,0 +1,20 @@
+# November 2 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/cranelift/2022/cranelift-11-16.md
+++ b/cranelift/2022/cranelift-11-16.md
@@ -1,0 +1,20 @@
+# November 16 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/cranelift/2022/cranelift-11-30.md
+++ b/cranelift/2022/cranelift-11-30.md
@@ -1,0 +1,20 @@
+# November 30 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/cranelift/2022/cranelift-12-14.md
+++ b/cranelift/2022/cranelift-12-14.md
@@ -1,0 +1,20 @@
+# December 14 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/cranelift/README.md
+++ b/cranelift/README.md
@@ -1,6 +1,6 @@
 # Cranelift project meetings
 
-The Cranelift project holds bi-weekly meetings, and we welcome all interested parties to join.
+The Cranelift project holds weekly meetings, and we welcome all interested parties to join.
 
 ## Time and location
 


### PR DESCRIPTION
In our meeting today (2022-09-21) we discussed whether it made sense to formalize the almost-weekly cadence we had been taking (which evolved from an overflow-into-next-week scheme) into fully weekly. We agreed to do so, and so this PR adds the remaining agendas for weekly meetings for the rest of 2022 (except for Dec 28, when I believe most of us will be on holidays).