### PR TITLE
Add sig-registries

### DIFF
--- a/sig-registries/README.md
+++ b/sig-registries/README.md
@@ -1,0 +1,18 @@
+# SIG Registries Meetings
+
+The Bytecode Alliance hosts weekly meetings as status updates on the
+design and implementation of warg, a WebAssembly component registry protocol and API. Anyone
+interested in this is welcome to join.
+
+## Time and location
+
+**When**: every Wednesday at 11am PST
+**Where**: Zoom (link in calendar invite)
+
+## Attending
+
+To attend, please email <bailey@cosmonic.com>, or reach out [on Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime).
+
+## Agendas and notes
+
+SIG Registries tracks meeting notes within the [SIG Registries repository](https://github.com/bytecodealliance/SIG-Registries/tree/main/notes).


### PR DESCRIPTION
For now, let's track meetings notes in the SIG-Registries repository while the discussions are still mostly about design and less procedural.