### PR TITLE
docs: add community agendas

### DIFF
--- a/community/2023/community-04-24.md
+++ b/community/2023/community-04-24.md
@@ -1,0 +1,19 @@
+# April 24th Community stream
+
+**See the [instructions](../README.md) for details on how to attend**
+
+6PM PDT on the last Tuesday of the month.
+
+## Agenda
+
+- Project Updates from:
+  - vscode-wit
+  - wamr
+  - wit-deps
+- Special Interest Group (SIG)
+  - Announcing SIG-TypeScript-Compilation
+
+## Links
+
+- [Slides](https://docs.google.com/presentation/d/1SKcQ-S2jWTHFMnvE6dXdydRCBUZCIkd9sLEz_2aTKt8/edit?usp=sharing)
+- [Stream and recording](https://www.youtube.com/watch?v=qGWB78K0uDU)

--- a/community/2023/community-05-30.md
+++ b/community/2023/community-05-30.md
@@ -1,0 +1,15 @@
+# May 30th Community stream
+
+**See the [instructions](../README.md) for details on how to attend**
+
+8AM PST on the last Tuesday of the month.
+
+## Agenda
+
+- Project Updates
+- Special Interest Group updates (SIG)
+
+## Links
+
+- [Slides](https://docs.google.com/presentation/d/1lJHhCnh5UwVIyIRkLjMVrq3dIVDkkB6sHrMJHe4BBHs/edit?usp=sharing)
+- [Stream and recording](https://www.youtube.com/watch?v=7JbQVdYPoI8)

--- a/community/2023/community-06-27.md
+++ b/community/2023/community-06-27.md
@@ -1,0 +1,15 @@
+# June 27th Community stream
+
+**See the [instructions](../README.md) for details on how to attend**
+
+6PM PST on the last Tuesday of the month.
+
+## Agenda
+
+- Project Updates
+- Special Interest Group updates (SIG)
+
+## Links
+
+- [Slides](https://docs.google.com/presentation/d/1nkH4PonN9nbyDMByG82zQC8B9ZFeZa-_MWvUtS3T81I/edit?usp=sharing)
+- [Stream and recording](https://www.youtube.com/watch?v=qynKt8b3yOw)


### PR DESCRIPTION
- Add tomorrow's community stream agenda
- Add placeholders for May and June
   Note that the slides and links to youtube
   will not need to change. I went ahead and
   scheduled the youtube event and created
   skeleton slides.