### PR TITLE
guest-js: Add notes for June meetings.

### DIFF
--- a/SIG-Guest-Languages/JavaScript/2023/guest-js-06-01.md
+++ b/SIG-Guest-Languages/JavaScript/2023/guest-js-06-01.md
@@ -1,4 +1,4 @@
-# June 29 project call
+# June 1 project call
 
 **See the [instructions](../README.md) for details on how to attend**
 
@@ -11,16 +11,20 @@
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
-    1. _Submit a PR to add your item here_
+    1. componentize-js
+	1. jco
+	1. JS -> Wasm leveraging SpiderMonkey JIT
 
 ## Notes
 
 ### Attendees
 
+* Kyle Brown
 * Guy Bedford
-* Calvin Prewitt
-* Saùl Cabrera
+* Danny Macovei
+* Saúl Cabrera
 
 ### Notes
 
-* Discussed [wasi-virt](https://github.com/bytecodealliance/WASI-Virt)
+* Saúl Cabrera presenting on using SpiderMonkey JIT to optimize JavaScript
+  compiling to a Wasm binary. Details of the presentation can be found at: https://github.com/saulecabrera/sm

--- a/SIG-Guest-Languages/JavaScript/2023/guest-js-06-15.md
+++ b/SIG-Guest-Languages/JavaScript/2023/guest-js-06-15.md
@@ -17,5 +17,12 @@
 
 ### Attendees
 
+* Kyle Brown
+* Guy Bedford
+* Danny Macovei
+* Saúl Cabrera
+
 ### Notes
+
+* Guy Bedford offered to a componentize-js on-boarding and code walk at an upcoming call.
 


### PR DESCRIPTION
This commit brings in the notes for all the meetings that happened in June. The original source of these notes is:
https://hackmd.io/ziSN-UOyQIObqqCXiPMNPA#JavaScript-Subgroup-of-Dynamic-Languages-SIG. When these meetings happened, we had not decided to to use this repo as the source of truth for notes and agenda.

cc/ @guybedford @Kylebrown9 @calvinrp 