### PR TITLE
Start using agendas for component model meeting

### DIFF
--- a/component-model/2023/component-model-09-27.md
+++ b/component-model/2023/component-model-09-27.md
@@ -1,0 +1,9 @@
+# September 27 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2023/component-model-10-11.md
+++ b/component-model/2023/component-model-10-11.md
@@ -1,0 +1,9 @@
+# October 11 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2023/component-model-10-25.md
+++ b/component-model/2023/component-model-10-25.md
@@ -1,0 +1,9 @@
+# October 25 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2023/component-model-11-08.md
+++ b/component-model/2023/component-model-11-08.md
@@ -1,0 +1,9 @@
+# November 08 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2023/component-model-11-22.md
+++ b/component-model/2023/component-model-11-22.md
@@ -1,0 +1,9 @@
+# November 22 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2023/component-model-12-06.md
+++ b/component-model/2023/component-model-12-06.md
@@ -1,0 +1,9 @@
+# December 06 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2023/component-model-12-20.md
+++ b/component-model/2023/component-model-12-20.md
@@ -1,0 +1,9 @@
+# December 20 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2024/component-model-01-03.md
+++ b/component-model/2024/component-model-01-03.md
@@ -1,0 +1,9 @@
+# January 03 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2024/component-model-01-17.md
+++ b/component-model/2024/component-model-01-17.md
@@ -1,0 +1,9 @@
+# January 17 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/2024/component-model-01-31.md
+++ b/component-model/2024/component-model-01-31.md
@@ -1,0 +1,9 @@
+# January 31 Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_

--- a/component-model/TEMPLATE.md
+++ b/component-model/TEMPLATE.md
@@ -1,0 +1,9 @@
+# {month} {day} Component Model Implementation Bi-weekly
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_


### PR DESCRIPTION
I've enough times wished now for a written down agenda to write on between weeks that I'm going to go ahead and start this up. I've deviated from the other templates in this repository by skipping the notes and attendees for now as I don't want to add too much process yet, but I figure this can at least serve as the start of having an agenda anyone can add to.