### PR TITLE
Add SIG Docs meeting notes from 2024-03-06

### DIFF
--- a/SIG-Documentation/2024/docs-03-06.md
+++ b/SIG-Documentation/2024/docs-03-06.md
@@ -35,6 +35,10 @@ Discussion at the February 28 SIG-Documentation meeting highlighted the need for
 * **Action Plan:** The current wasi.dev site isn't properly operational or up to date, and was built using tools that need to be replaced.  The group agreed that it is both important and feasible to get a basic updated version in place in roughly two weeks, along with a plan for growing the site over time.
 * **Apportioning the Work:**  An initial skeleton for the new site, shared through the existing wasi.dev [site repo](https://github.com/bytecodealliance/wasi.dev), will be useful in helping identify content development needs (as Issues) as well as looking for volunteers to be part of that work.
 
+### Next Meeting
+
+A few group members will be unavailable next week due to attendance at Wasm I/O, but others agreed to meet as scheduled to review progress on reconstruction of wasm.dev.
+
 
 ## Action Items
 

--- a/SIG-Documentation/2024/docs-03-06.md
+++ b/SIG-Documentation/2024/docs-03-06.md
@@ -9,16 +9,34 @@
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
     1. Brainstorm new structure and content for wasi.dev
-        1. Working document for site changes: [https://hackmd.io/@ericgregory/Skq9FC336/edit](https://hackmd.io/@ericgregory/Skq9FC336/edit)
+        1. [Working document](https://hackmd.io/@ericgregory/Skq9FC336/edit) for site changes
+    2. Next Meeting
 
 ## Attendees
 
-* TODO
+* Kate Goldenring, Fermyon
+* Calvin Prewitt, JAF Labs
+* Danny Macovei, JAF Labs
+* Eric Gregory, Cosmonic
+* Mikkel Mørk Hegnhøj, Fermyon
+* Ryan Levick, Microsoft
+* David Bryant, Bytecode Alliance
 
 ## Notes
 
-* TODO
+Discussion at the February 28 SIG-Documentation meeting highlighted the need for expanded and enhanced documentation on WASI as a counterpart to the recently published [WebAssembly Component Model book](https://component-model.bytecodealliance.org/).  One option proposed then was to leverage the existing wasi.dev site, which Eric took an action item to explore and report on today. He shared findings from that work and led discussion of likely site structure, content, development, and deployment:  
+
+* **Leveraging Prior work:** Late last year a brainstorming effort to reboot wasi.dev produced a variety of [useful notes](https://gist.github.com/pchickey/2de6b682c0f7c2464c719e260e6901dc) as a profile on the WASI community, and will be helpful now in planning next steps for the site.
+* **Target Audience:** We would like the site to  provide both a introductory perspective on WASI (e.g., for a curious journalist) and serve as an on-ramp and reference for developers keen to use it.
+* **Nature of the site:** We intend for the site to evolve actively and change regularly, with a growing variety of new content.  The site should therefore be built using a content platform that supports growth and broad collaboration.  Several options were discussed in comparison to similar sites, with good overall interest in using [Markdown Book](https://rust-lang.github.io/mdBook/index.html).
+* **Ownership and Positioning:** Wasi.dev is not managed by the Bytecode Alliance directly, and therefore SIG-Documentation can comfortably take on oversight and evolution as a community effort supported broadly by Members and volunteers through the SIG.
+* **Overall Content:** Eric's working document included a proposed outline structure for the site with content areas to be covered, which the group discussed and refined in the meeting.
+* **Relationship to the Component Model Book:**  It will be important to have clear distinctions between what content is best suited for wasi.dev and what should be covered in the Component Model book. This will need some thought and attention in formulating an overall plan for development of wasi.dev.
+* **Action Plan:** The current wasi.dev site isn't properly operational or up to date, and was built using tools that need to be replaced.  The group agreed that it is both important and feasible to get a basic updated version in place in roughly two weeks, along with a plan for growing the site over time.
+* **Apportioning the Work:**  An initial skeleton for the new site, shared through the existing wasi.dev [site repo](https://github.com/bytecodealliance/wasi.dev), will be useful in helping identify content development needs (as Issues) as well as looking for volunteers to be part of that work.
+
 
 ## Action Items
 
-* [ ] TODO
+* [ ] Construct an intial Markdown Book based skeleton for the renewed wasi.dev as a branch in the existing repo, both as a useful replacement of the existing site and a framework for ongoing creation of desired new content. (Eric, Calvin)
+* [ ] Continue to review and comment on the working document for site changes. (All)


### PR DESCRIPTION
Adding notes for SIG-Documentation from its March 6, 2024 meeting.