### PR TITLE
Publish TSC minutes for Apr 23, 2024

### DIFF
--- a/TSC/2024/tsc-04-23.md
+++ b/TSC/2024/tsc-04-23.md
@@ -1,0 +1,39 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 23, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant, Secretary (note taker)
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories. Areas of discussion included preliminary review of a revised SIG Embedded proposal and compatibility across WASI preview1 and preview2 environments. 
+
+### Topic #2
+
+Recognizing the benefit of periodic review of the Alliance Code of Conduct and published operational values, the TSC shared observations gained from comparing our current versions to cited reference materials such as the Contributor Covenant as well as recent governance updates made by other similar organizations.
+
+**Action:** David and Till will gather possibilies for governance updates to be considered by the TSC. 
+
+### Topic #3
+David observed that the Alliance now has over one hundred Recognized Contributors and suggested this is a milestone we should highlight to both RCs and to our Membership. 
+
+**Action:** David will make sure our published list of RCs is suitably up-to-date and help draft a blog post to share the news on the Alliance website.
+
+### Topic #4
+Our next Bytecode Alliance community video stream will happen next Tuesday via our YouTube channel.  Bailey highlighted the current agenda  and guest presenter plans.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:02am PT
+
+David Bryant  
+Secretary of the meeting

--- a/TSC/README.md
+++ b/TSC/README.md
@@ -8,8 +8,8 @@ TSC composition, role, and scope are defined in its [charter](https://github.com
 
 ## Time and Location
 
-**When**: every Tuesday at 10am PST
-**Where**: On video via Zoom
+**When**: every Tuesday at 10am PST  
+**Where**: On video via Zoom  
 
 ## Attending
 TSC membership is currently defined as three delegates elected by Recognized Contributors and an appointed delegate from each Core project. The TSC receives operational support from the Bytecode Alliance Executive Director.


### PR DESCRIPTION
Added minutes from the April 23, 2024 TSC meeting.  (Also fixed one minor formatting glitch in the TSC subfolder's README.)