### PR TITLE
Publish TSC minutes for April 30, 2024

### DIFF
--- a/TSC/2024/tsc-04-30.md
+++ b/TSC/2024/tsc-04-30.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 30, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant, Secretary (note taker)
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories.  
+
+### Topic #2
+
+David provided an update on his review of our Recognized Contributor mailing list, identifying addresses that need to be updated relative to our current roster.  The TSC also discussed the process of identifying, reviewing, and adding new RCs to make sure RC communications are as streamlined as practical going forward.
+
+### Topic #3
+The TSC discussed the current work and growing interest in providing registry services as a shared, public resource, including coordinating progress on registries across active projects.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:52am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Update to add meeting minutes from the April 30, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).