### PR TITLE
cm/announcement: add wRPC to 05-08 meeting

### DIFF
--- a/component-model/2024/component-model-05-08.md
+++ b/component-model/2024/component-model-05-08.md
@@ -4,6 +4,6 @@
 
 ## Agenda
 1. Announcements
-    1. _Submit a PR to add your announcement here_
+    1. [wRPC](https://github.com/wrpc/wrpc) - WebAssembly component-native RPC framework based on WIT
 1. Other agenda items
     1. _Submit a PR to add your item here_


### PR DESCRIPTION
I've been working on wRPC (https://github.com/wrpc/wrpc) for the last few months and would like to present it at the next component-model meeting

wRPC (WIT-RPC) is a Wasm component-native transport-agnostic RPC protocol and framework, which facilitates execution of arbitrary functionality defined in WIT (WebAssembly Interface Type) over network or other means of communication.

Main use cases for wRPC are enabling out-of-tree Wasm runtime plugins and distributed component communication.

wRPC uses component model value encoding (fully defined and pending spec merge at https://github.com/WebAssembly/component-model/pull/336) over the wire.

wRPC supports both dynamic (based on e.g. runtime component type introspection) and static use cases. For static use cases, wRPC contains a `wit-bindgen` fork within the repo providing binding generators for Rust (close to MVP) and Go (WIP)