### PR TITLE
Add [#8530] to ML agenda

### DIFF
--- a/machine-learning/2024/ML-05-13.md
+++ b/machine-learning/2024/ML-05-13.md
@@ -11,7 +11,10 @@ See the [instructions](../README.md) for details on how to attend.
 1. Proposals and discussions
     1. Discuss how to communicate different graph encoding versions (e.g., ONNX opset); Stuart
        Schaefer
+    1. Discuss removal of preview1-compatible Wasmtime implementation ([#8530]); Andrew Brown
     1. _Submit a PR to add your announcement here_
+
+[#8530]: https://github.com/bytecodealliance/wasmtime/pull/8530
 
 ### Attendees
 


### PR DESCRIPTION
This PR removes preview1 support for wasi-nn in Wasmtime; let's discuss the ramifications.

[#8530]: https://github.com/bytecodealliance/wasmtime/pull/8530