### PR TITLE
Publish TSC meeting minutes for May 7 and 21, 2024

### DIFF
--- a/TSC/2024/tsc-05-07.md
+++ b/TSC/2024/tsc-05-07.md
@@ -1,0 +1,39 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 7, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant, Secretary (note taker)
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories.   
+
+### Topic #2
+
+The TSC considered a request from a WebAssembly project for adoption by the Alliance as a Hosted Project. This led to a discussion of consistency in response to such suggestions, both when the project is seen to be a good potential candidate for Hosted Project status and when it is not (or is perhaps too early in its lifecycle to decide).
+
+**Action:** David will draft a reply to the project that volunteered for adoption, aligned with the TSC's proposed framing.
+
+
+### Topic #3
+Bailey reported that four different project related activities have simultaneously proposed new blog posts for the Alliance website as an update on their work. She asked that the TSC stand by to provide timely review of those posts and help stage them out over the coming weeks.
+
+### Topic #4
+Based on the recent announcement that WasmCon 2024 would move to November in Salt Lake City, the TSC discussed implications for Alliance events, including anticipated ones such as our recurring Plumbers Summit and hands-on hackathons as well as other gatherings it might be appropriate for the Alliance to host.
+
+**Action:** David and Bailey will share the TSC's ideas with the Bytecode Alliance Board and report back on consensus next steps.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:42am PT
+
+David Bryant  
+Secretary of the meeting

--- a/TSC/2024/tsc-05-21.md
+++ b/TSC/2024/tsc-05-21.md
@@ -1,0 +1,37 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 21, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant, Secretary (note taker)
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, as well as ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reveiwers on the requests discussed.   
+
+### Topic #2
+
+The TSC reviewed and approved David's draft response to a proposal received regarding a potential new Hosted Project, allowing him to send it on behalf of the TSC.
+
+### Topic #3
+David summarized progress in reviewing the Alliance's Recognized Contributor (RC) roster. The TSC discussed how to properly maintain the roster given the possibility that contributors might move away from projects into new areas and therefore no longer be actively involved in Alliance communities, and also that active RC status is tied to active voting in relevant elections per language in the TSC charter.
+
+**Action:** The TSC will revisit at a future meeting the practical mechanics of managing the RC roster, especially in the context of voting in RC elections.
+
+### Topic #4
+Till highlighted cases where ongoing Alliance project work needed some additional attention in order to maintain the vendor-neutral posture required on behalf of the Alliance. The TSC discussed proper framing of guidance it would give in order to clarify and reinforce vendor neutral positioning, and the possibility that some additional work would need to be coordinated to provide vendor neutral implementation, documentation, and examples for Alliance projects.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:06am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Adding minutes for the May 7 and May 21 2024 TSC meetings to the 2024 subfolder of the TSC archive here.  The TSC did not meet on May 14, 2024.  (Apologies for missing that the May 7th meeting minutes had not been previously posted.)