### PR TITLE
Publish TSC minutes for May 28, 2024

### DIFF
--- a/TSC/2024/tsc-05-28.md
+++ b/TSC/2024/tsc-05-28.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 28, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneiderreit  
+
+**Others present:**  
+David Bryant, Secretary (note taker)
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, including the formation of new Special Interest Groups, as well as ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed.   
+
+### Topic #2
+David called attention to recent discussion on the Alliance Zulip server in which community members suggested broader visibility of WebAssembly Component Model reference documentation and examples, to which SIG Documentation has responded and is acting upon.
+
+### Topic #3
+Till observed that the WebAssembly W3C Community Group is hosting an in-person hybrid meeting next week in Pittsburgh, Pennsylvania, a portion of which overlaps with the regularly-scheduled TSC meeting time. As a result, next week's TSC meeting has been canceled.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:03am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish meeting minutes from the May 28, 2024 Technical Steering Committee (TSC) meeting.