### PR TITLE
Launch SIG Embedded and announce plans for its first meeting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@
 /SIG-Registries/ @bytecodealliance/sig-registries-chairs
 
 /SIG-Community/ @bytecodealliance/sig-community-chairs
+/SIG-Embedded/ @bytecodealliance/sig-embedded-chairs
 
 # Projects
 /component-model/ @bytecodealliance/wasmtime-core

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ You can find the joining info for future meetings and notes for past meetings of
   * [C# Subgroup](./SIG-Guest-Languages/Csharp) (bi-weekly)
 * [SIG-Registries](./sig-registries) (weekly)
 * [SIG-Community](./SIG-Community) (first and third Tuesday of each month)
+* [SIG-Embedded](./SIG-Embedded) (meeting details to be announced)

--- a/SIG-Embedded/README.md
+++ b/SIG-Embedded/README.md
@@ -1,0 +1,27 @@
+# SIG-Embedded Meetings
+
+A meeting for the the Bytecode Alliance Special Interest Group (SIG) for Embedded and Industrial Applications [(SIG-Embedded)](https://github.com/bytecodealliance/governance/tree/main/SIGs/SIG-embedded).
+
+## Time and Location
+
+**When**: Meeting details to be determined, with an initial meeting to be announced in the [SIG-Embedded channel](https://bytecodealliance.zulipchat.com/#narrow/stream/438936-SIG-Embedded) on the Bytecode Alliance Zulip  
+**Where**: On Zoom, with details and a meeting link forthcoming here.
+
+## Attending
+
+To get the passcode to attend, please reach out [on
+Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/438936-SIG-Embedded).
+
+## Agendas and Notes
+
+Both agendas for upcoming and notes for past meetings will be posted in
+subdirectories for each year.
+
+## Adding Agenda Items
+
+To add something to the agenda for an upcoming meeting, open a pull request to
+modify the agenda.
+
+## Live chat and Q&A
+
+Can't make it to the meeting? Chat and Q&A is in the Bytecode Alliance Zulip [SIG-Embedded channel](https://bytecodealliance.zulipchat.com/#narrow/stream/438936-SIG-Embedded).

--- a/SIG-Embedded/TEMPLATE.md
+++ b/SIG-Embedded/TEMPLATE.md
@@ -1,0 +1,24 @@
+# {month} {day} SIG-Embedded Meeting
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+
+1. Opening, welcome and roll call
+1. Announce that the meeting will be recorded and hit record as agreed upon in inaugural meeting. 
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Attendees
+
+* TODO
+
+## Notes
+
+* TODO
+
+## Action Items
+
+* [ ] TODO

--- a/machine-learning/2024/ML-06-10.md
+++ b/machine-learning/2024/ML-06-10.md
@@ -15,8 +15,507 @@ See the [instructions](../README.md) for details on how to attend.
 
 ### Attendees
 
-- _Fill in after meeting_
+- Hung-Ying Tay (@hydai)
+- Matthew-Tamayo Rios
+- Andrew Brown
+- Mingqiu Sun
+- Johnnie Birch
 
 ### Notes
 
-_Fill in after meeting_
+@hydai presented the changes that WasmEdge made to wasi-nn to support their LlamaEdge use case.
+- first, he described the changes made to the wasi-nn spec and bindings ([source])
+- then he walked through some GOSIM slides ([presentation])
+- he talked through WasmEdge's ongoing effort to support the component model ([issue]) -- should be
+  possible before the end of the year
+- finally he discussed several alternatives to speeding up LLM inference on Intel devices (e.g.,
+  [`neural-speed`], [`intel-extension-for-transformers`])
+
+[source]:https://github.com/second-state/wasmedge-wasi-nn/blob/ggml/rust/src/graph.rs
+[presentation]: https://docs.google.com/presentation/d/1FwaEVob-u6fVmXQTUqPpguV-1rjVBtEJEiheR3kL1aA/edit#slide=id.g26fc8f7470e_1_17
+[issue]: https://github.com/WasmEdge/WasmEdge/issues/3151
+[`neural-speed`]: https://github.com/intel/neural-speed
+[`intel-extension-for-transformers`]: https://github.com/intel/intel-extension-for-transformers
+
+What follows is the Microsoft Teams transcript of the meeting:
+
+hydai: OK so. Ohh, this is slide I present in the GOSING 2024 in the European and. Sorry, let me
+share the screen, I forgot it. So can you guys see my screen now?
+
+Andrew Brown: Yeah.
+
+hydai: OK, great. So. We built the normalized which is using our forked version of. The was the one
+that were proposal and before I start to introduce the detail I want to, you know, just mention what
+kinds of changes we met in the forked version. So let's go to the the this repository. Uh, he shows
+that the wasn't. It was the, you know, when I work and this is just folks from the official. Ohh
+Washington and Network repository and so first thing we add is the ML graph encoding is a new back
+end and we are going to add more including the Apple MLX framework and the Intel network speed. Uh
+framework into the graph encoding and it should be 8 year. Just believe it's one in one or two
+weeks. We will update and we will add more here and the other thing is that we may. Also add a new
+execution target which called the MPU.
+
+Andrew Brown: Mm-hmm.
+
+hydai: Is the new ship. From the you know the ATC or some AI embedded uh Development Board, they all
+have MU. So we would have a new one to you know, to identify it. And the other part is that we have
+some. We have some Cinco. Uh. Ready to function because that's a all almost our current use case.
+Uh. Based on the LLM and how the LLM handle the input and the output is basically the you know the
+tokens so. Ohh instead of just send the whole input or for output we would like to just sequentially
+use it into the single token so you can find that we have some single related function which will
+allow the developer or the application users to produce only a single token and when the token
+string is all finished he should call the finalized to terminate the whole execution.
+
+Andrew Brown: Hmm.
+
+hydai: So so this is the basic idea we add for the LM and.
+
+Andrew Brown: Can can I ask a question about that?
+
+hydai: Sure, sure.
+
+Andrew Brown: Is this essentially essentially a way to stream the tokens 1 by 1 until we get to the
+end? Mm-hmm.
+
+hydai: Ohh yeah, we hope we we can do this by streaming, but you know that that the Watson didn't
+allow any synchronized discussion or let's real stream, right?
+
+Andrew Brown: Yep.
+
+hydai: So we have used a while loop to code these for each guest single token function or the
+computer single function, but in a while loop until you reach the maxima token limitation or enrich
+the token you want. So we actually have to, you know, use a Infinity loop to call it and call it and
+call it.
+
+Andrew Brown: Umm. Yeah, yeah, yeah, yeah.
+
+hydai: Yeah, to to simulate the the the streaming process, yeah.
+
+Andrew Brown: Right, right. Yeah. Gotcha.
+
+hydai: Yeah.
+
+Andrew Brown: Yeah.
+
+hydai: And we hope that you know when you come, when the component model has the streaming type, you
+know, maybe we don't need this, but as a workaround, we have to do that. Yeah.
+
+Andrew Brown: Yep, Yep.
+
+hydai: Yeah. And this is just a relative financing he here is the get output single just to get only
+one token. Yeah. And after that we also add a function. I believe we may discussion this function
+before, but is still not in the spec. Ladies, we introduce unload function which allow you to unload
+a loaded model. So why this this function is really important is that uh, in the current user case,
+our user may load multiple LM model to handle different type of the uh their mission. But one thing
+is that most of the people don't have a very large rerun or memory devices, so it's not possible to
+load, for example, the damn mastery and define.
+
+Andrew Brown: Hmm. Mm-hmm.
+
+hydai: Sorry and lots of different model to handle the different request so they have to switch the
+model and that's why we have a node here because we have to unload the previous model to carry out
+the whole fever and space for the new model. And uh, I'm not sure if we can introduce a swap concept
+or something like that, but as a walk around we have to use unload now. Yeah, so.
+
+Andrew Brown: Yeah. Can I ask a question about that?
+
+hydai: Check.
+
+Andrew Brown: So so a lot of people are using web assembly in a very like quick instantiation run
+for a short period of time and then you know. You know, dump the entire Web assembly instance and
+we're done. But you're kind of describing a scenario where people are running a web assembly
+instance for considerable amount of time, or at least enough time where they're swapping models in
+and out.
+
+hydai: The.
+
+Andrew Brown: And in that case you kind of need, well, you need some way to swap them in and out.
+Can you describe, like, uh in I maybe you don't want to share all the details but like, why are they
+running models for a long period of time? What's causing them to do that and why is the Web assembly
+instance alive for so long? That's kind of interesting. So different side to this.
+
+hydai: OK so I have an use cast which is a. We will have the visual model.
+
+Andrew Brown: Yep. Gotcha.
+
+hydai: The only thing they did is to, you know, analyze several invoices and then it will just
+compose those information into CSV or just file, right? And we have to use another LM such as file
+#3 and then to ohh. Analysis please.
+
+Andrew Brown: Gotcha.
+
+hydai: Uh, base stress vile and then do some anything that they want. And we have several pipelines
+just like this because that's the open source model. Don't have some very powerful behavior, just
+like the open aids.
+
+Andrew Brown: Right.
+
+hydai: You know the open the GBD for. Oh, you can include in the video the voice and lots of
+different kinds. Just in one model, but in the open source model. Uh, are you scared we have to
+switch the different model? Yeah. So let's why, you know, we have this scenario.
+
+Andrew Brown: Gotcha. So you have a chain of models, and as each model hands off to the next link in
+the chain, you kind of need to unload the previous one.
+
+hydai: Yeah, yeah, yeah. And actually you see you you have a, you know you have a extra 100 or you
+have, you know, a very large GPU then it's fine. But most of people doesn't. Yeah.
+
+Andrew Brown: Yeah.
+
+hydai: So there's there's a big question. Yeah. Yeah.
+
+Andrew Brown: Yeah, makes sense. Thanks.
+
+hydai: So yeah, so there's there's what we ate for the LAN scenario and let me check if I miss
+anything. Oh, and I have this one which is low by name.
+
+Andrew Brown: Umm.
+
+hydai: With config for which is that uh, due to the current, you know LMC scenario, uh, there are
+some very detailed seeing you have to set up before you load the model which is that you can control
+a how many layers are offloading to your GPU because you know some GPU is really, really small. So
+you can not fully load in a model into it, so you have super filet and uh there's no way to.
+
+Andrew Brown: Mm-hmm.
+
+hydai: Cool to configure it before the note, so I I didn't see there is a, you know a very very a
+good way to do that.
+
+Andrew Brown: Umm.
+
+hydai: So there there's a another issue we we can contact. So yeah, this is for the graphite and we
+because that, uh, please correct me if I'm wrong, which is that. This is this that we don't have a
+custom error can provide by user in the OR. Uh, very, you know, flexible error code.
+
+Andrew Brown: Mm-hmm. Yep.
+
+hydai: So we can embed the error number or the error message you know customized way, yeah, because
+that's when we run the LM model here, we have some very important information. Must be, you know.
+
+Andrew Brown: Yeah.
+
+hydai: Uh, send these errors spatially application layer because that LM may fail due to lots of
+issue. For example, it just find the end of sequence token. Maybe the color school or your price is
+too long, so we cannot handle it, or even that's the the model is working on. The model is not
+found, you know, so that's a very specific error. We should will only produce by the LM use tabs. So
+let's say if you are using the object detection, you don't have the contacts for error here. Yeah.
+So this is another thing we could encounter and as a workaround we we just extend this back end
+error here and I believe we will have a you know a more flexible way to to do this. Yeah. So this is
+all of the, uh, modification we met. And so that's why we have the llama Llama edge idea is that we
+use the following API and we would like to Mac user to control their uh LM pipeline by using this
+API.
+
+Andrew Brown: Umm.
+
+Mingqiu Sun: How do I?
+
+hydai: And of course we we we pack uh, this detail, this low level API into a high level class or a
+structure so so you shouldn't need to, you know worry about very details in just like ohh I can get
+the next token yeah so so we also arrived the latch so that's why we call it damage the idea is that
+we just package all of the details things in the what's DNN and provide a high level idea for those
+who want to do their you know customized pipeline so ohh yeah. Yeah sure.
+
+Mingqiu Sun: A question was still I still don't get it. What? What's the difference between computer
+and the computer single?
+
+hydai: Ohh up, because the computer function is blocking function. OK, So what you call the compute
+function? You will just, uh, do the whole inference until uh. No end of sequence font or the contest
+is content size is full. However, most of the use cases, if you find that the LM is not produced a
+correct answer sequentially, you can just terminate in it and say hey, you are wrong. So if you
+don't need to finish your inference now, we want to terminate the yet and then do analysis. So
+that's why we have computer single. So you can just judge it token by token, not use a single
+computer function.
+
+Mingqiu Sun: Right, right.
+
+hydai: That is my understanding of the.
+
+Mingqiu Sun: Yeah, but my my question is really, you know, can you do multiple compute in the room?
+You know, isn't that like a exactly what you want for computing go? Just just like a do multiple.
+You know in the loop and and you finish the whole sentence token by token.
+
+hydai: Yeah, we we definitely can do this, but the idea is that. Uh, our initial understanding is
+that. This computer function is designed for, for example, if you you do the object detection, you
+will just finish the detection and then done right. So that's why we we just separate, but it is
+very easy to merge it back. It is nothing right?
+
+Mingqiu Sun: Umm.
+
+hydai: But uh, that's why we, you know, we just want to separate the the different use task because
+that we believe this function can just replace by the streaming type which will be introduced in
+company model later. So you will help us to, you know, to do more easy way to maintain it, yeah.
+
+Mingqiu Sun: OK. OK. Thank you.
+
+hydai: Yeah. So. So we we we pack it and then we jumped into, we jump into a scene is that in this
+llama add we would like to. The most important is here. Uh, because that, uh, they are so many
+different models. So once is that we want to use the damage to allow user to. Control how many model
+they want to download. They want to use and the other thing is that we would like to support a
+different multiple uh GPU framework in including the CUDA framework, MLS or metal and all of the
+detail will behind into the you know, the neural network spec because we we all have the graph
+encoded to describe where the different from work. Yeah, so. And one thing is that because the most
+of the use case of LM will response in just an or, the function coding ohh. Style. And is it should
+not be done in the. Wastelands back because she's too, too high level, so we also provide these
+functionality in the lab manage project and we include in the IG use CAS and the the most of the
+idea is that the only thing you do is to write a rust application and use this high level API to
+control all the staff. Yeah. So this is the best idea. Why we build the damage with our folks
+version? So maybe I can just show. The. Ohh here is the current integration. Uh, we have and we we
+demo yet, which is you can just use a. You know, this is this is a. Something like a picture you
+manage tool or. And the control tool which is called the GIONET and the everything you need to do is
+to give it and configuration file to specify which model you want to download and what kind of the
+embedding vector or embedding database you want to use and what kind of the. Ohh knowledge, stand
+shop. You want to use and actually define it. You can run this tool called the Bayonet in it and you
+will just download all the models and save the data back to database and say have the knowledge base
+and then it will start a simple you know HTTP server so you can interact with it. And the whole idea
+is when it start actually is running the wasn't it run high which is just wasn't run high and it's
+using the what's new network spec to interact with all of these models? Yeah. So there's our also
+this this is an open source project, so you can just Google Guyonnet on and then follow the
+remaining and you can just you know just you see it, yeah. So the there's what we.
+
+Mingqiu Sun: But hi there another question.
+
+hydai: Yeah, yeah, yeah, yeah, sure.
+
+Mingqiu Sun: So I I know you guys have the wasn't edge long time supporter here. Do you welcome
+like, a a other longtime support, or you want to, like, focus on why don't edge only?
+
+hydai: Ohh of course we we would like to have multiple runtime right? But the question is we we are
+using our folks was in the proposal for the LM style and I'm afraid our modification is not going
+to, uh marching to the. Was she? And proposal now, because that's the whole project is just
+transitioned into the computer model, right? So I'm not sure if other runtime would like to
+implement these functions.
+
+Mingqiu Sun: OK.
+
+hydai: There will be a question, but in my mind I I'm I'm open to and I am happy to have multiple
+online here because it will. It will increase in the robust, right?
+
+Mingqiu Sun: OK. Thank you.
+
+Andrew Brown: Well, from my perspective, uh now is a great time to make changes to the spec as we're
+switching to the component model, the the older preview one stuff is kind of like frozen in time. I
+don't know how much we can go back to that and and make changes to that. There's not a great
+versioning strategy there, but the in terms of the the Preview 2 supported spec, I've kind of made
+some notes. I you know, a lot of what you've said here has made sense, right? Configuration and
+maybe even the streaming stuff. A better error handling all that kind of stuff seems like a great
+thing to.
+
+Mingqiu Sun: And and I don't know, I think on low is a is needed, don't you think so and you?
+
+Andrew Brown: Perhaps so. Yeah, yeah, yeah. So I I yeah like, but I I I'm not sure where you guys at
+with component model support or preview two baby I support.
+
+hydai: Sure. So let's go to my second presenting.
+
+Andrew Brown: OK, there you go.
+
+hydai: Sorry I I don't have a slide for it. Yeah, but the idea is that and because you know
+introduce the whole component model support ohm, it is a huge drop, right? So we are focusing on ohh
+Los Freaker. Who? Which will only be used in the previous two proposal and. Uh, if you want to check
+our implementation, you can just follow.
+
+Andrew Brown: Mm-hmm. Mm-hmm. Yeah, yeah.
+
+hydai: You know this issue and then this is all talk about the essential that and we also have
+another issue is for the validation but umm just want to you know reduce the implementation coast
+which are separating it and we don't verify it any component model wasn't so if you give me a broken
+component model wasn't and we will try to execute it and fail.
+
+Andrew Brown: Yeah, yeah.
+
+hydai: Yeah, but all of these needs just focusing on this and discussion, right? So we already have
+some best definition, so we can pass a component model water now and we will have. Uh to examples.
+Uh, I believe it's in the.
+
+Andrew Brown: Yeah.
+
+hydai: Sorry, in the end of this month for which is that we support a string type and so you can use
+the was the HTTP proposal now and we also will have the RC poll which we may be merged into another
+proposal anyway. But so our first support proposal is the washer SVP and we believe very simple. The
+stuff on machine and no.
+
+Andrew Brown: Cool. Umm.
+
+hydai: Ohh sorry and most of the component types will be supported in the August and we will have
+the resource control in the support Hamburg and also we we we have two you know two very important
+things but we are not going to fully explore it which is the impose and the expose of course we will
+impose the parking module or the component instance but according to the definition there are lots
+of different you know impose they have to support it but we were just left them behind because that
+most of the current proposal are not using.
+
+Andrew Brown: Mm-hmm.
+
+hydai: It and of course if we watch you right, network will need that. Then we can just add in into
+our world map. So I believe most of the previous two proposal should be support at the end of this
+year. Yeah.
+
+Andrew Brown: Cool.
+
+hydai: And we believe there are, you know, some implementation problem, but we will, you know fix
+that, yeah.
+
+Andrew Brown: Yeah, yeah, yeah. I mean I I think that resource is blocked you have there. You know,
+one of the key things that we switched to with the in Waze and then with the component models like
+tensors and models will be resources. So we'll be passing them around to kind of handles instead of
+just raw 30 twos. And so as soon as you guys get that support, I I'm kind of thinking, hey, then
+that's maybe the final missing piece to use the preview to API style stuff. Yeah.
+
+hydai: Yeah, this this current actually we also have lots of different property in which are also
+will relied on the resource part because that's they have to you know. I'll have the ownership of
+the resource, yeah.
+
+Andrew Brown: Umm.
+
+hydai: Yeah.
+
+Andrew Brown: Cool.
+
+hydai: So this is very short, but we have the rough time timeline here and yeah, so this old man
+stance.
+
+Andrew Brown: Well, that that's that was actually really helpful to understand. Yeah, the changes
+the. You know the the, the, the rationale behind the changes and then also where the component model
+state is in wasmade. Does anyone else have any questions for Heidi about what you just presented?
+
+Johnnie L Birch Jr: I don't have a specific question. I I I do wanna go and see the presentation
+that was given, but I I just think this is very interesting, but you've guys been able to achieve
+this with the Wasian and Hadi and by the way, if you have familiar who I am, I I work with Minthu
+and Andrew here at Intel. But yeah, I would be interested if from if you have availability for you
+to present the this work that you've been doing, not necessarily these you know find implementation
+details about the differences, but just in general what you've been able to accomplish to a wider
+audience. So I I kind of want to touch base with you on that if I can.
+
+hydai: Umm. Oh, and I believe they are. You're working in in here, right? So actually I do have a
+question, which is that we found there is an open vinyl and the newer speeds. And we also find the
+180I.
+
+Andrew Brown: Yeah.
+
+hydai: I'm not sure which one is the a fast option to integrate us a back end because we we are so
+confused due to that the different framework. Ohh can run the L you know.
+
+Mingqiu Sun: Yeah, yeah, yeah. So let me try to help you. So yeah, this is a very good point. You
+know, even a lot of Intel engineers, they are confused about that as well.
+
+hydai: Umm.
+
+Mingqiu Sun: So open Vino is a product and it built on top of A1 API. So I think if you are
+interested in back end only you know one API is is the right approach. You know is support like a
+keep your GPU and MPU, you know in the future. So I think that's probably like a lot lighter way
+than like integrating the whole product into into your project does does. Does this answer your
+question?
+
+hydai: Uh, sure. And we also find that the reason we just integrate the new world speed framework is
+because we found that there is a project called the Intel. Sorry, the inhale transformer is tension
+or something like that and you just use the neurosphere framework. So we choose it to run the LM,
+but I'm not sure why the relationship between this one and the one API.
+
+Mingqiu Sun: Yeah, that.
+
+Andrew Brown: Yeah, can. Can you send some links?
+
+Mingqiu Sun: That is, that is a good question, yeah.
+
+hydai: Ohh sure sure, sure. Sorry.
+
+Mingqiu Sun: Yeah, that.
+
+Andrew Brown: I think because I can't you, I can't. Yeah.
+
+Mingqiu Sun: Yeah, the transformer extension is is like a business BU initiative out of our like a
+data center group. So it's relatively new and I assume that it will be built on top of A1 API or you
+know it's it's it's more like a specialized you know packaging of 1 API and the additional
+transformer related you know thing together. So so I I think a betting on one API is alright
+approach.
+
+Andrew Brown: Yeah, one APIs are are low level.
+
+hydai: Yeah, but I umm.
+
+Andrew Brown: Our low level like library for accessing the hardware directly. It's kind of the
+hardware abstraction layer plus a little bit on top so that it feels a little bit more stable than
+you know. If you think up like a couple of level levels above that are open vino and this neural
+speed and Intel extension for transformer and so it's the one API is definitely the thing that's
+gonna be around for a while. Seems like.
+
+hydai: Yeah, but I believe there will be another issue, which is that if you only use the one API,
+then to run a LM I believe we will be very hard to implement it.
+
+Andrew Brown: Yeah. Yeah, yeah, yeah, yeah.
+
+hydai: The reason is that different LM will rely on different tokenizer and the the handler and it's
+pretty hard to implement those.
+
+Andrew Brown: Yeah, yeah. Yeah, yeah, yeah.
+
+hydai: Uh, preprocessing and post processing in the wasn't there?
+
+Andrew Brown: Yeah, it's a it's.
+
+hydai: So there will be a very busy question.
+
+Andrew Brown: It's almost too low level, right?
+
+hydai: Yeah, yeah, yeah, yeah.
+
+Andrew Brown: It's like too low level for you. You need a framework on top, but deciding which
+framework on top you know is. I don't know. Maybe we should get back to it. Sure. Like.
+
+Mingqiu Sun: Yeah. Yeah, we'll probably do some, you know, research on our own, you know, because
+this is such a hard area. So a lot of different part of Intel, you know, they came up with, you
+know, new project ideas. So uh, so it's it's in the yeah, this needs to be sought out.
+
+Andrew Brown: Umm.
+
+hydai: Yeah, but a in our current ideas that because we we probably in flats different, you know
+different from work have layer own, you know fans. So currently we are just you know integrate as
+much as possible, but I believe you may be you know increasing our maintenance cost but yeah, so so
+I I would like to have the best one if if there is any, yeah. Umm.
+
+Andrew Brown: I mean my my hot take right now is that you're looking for a framework that's high
+level but also has the performance of a low level one API self thing. And I think what several of
+these frameworks are trying to do is they're trying to integrate with like for example, Pytorch or
+GPML or something like that. And they're they're trying to sort of integrate one API with an already
+existing framework. And actually I think that's a pretty good approach because for example in the
+Pytorch case you get all the established goodness of pie torches, like years of work, but then you'd
+also by adding this whatever extension that whatever one of these extensions is, you know you would
+get faster access to the hardware via one API. I think that's kind of the model that to me makes the
+most sense in this scenario, kind of using an already existing framework plus the one API extension
+stuff.
+
+hydai: Yeah, we we can try that. Yeah, and. The the reason we want really want to pick up and you
+know and Intel framework is that we believe uh, the one API or the related framework can leverage
+your maximum performance and the Intel devices because that's my.
+
+Andrew Brown: Yeah.
+
+hydai: So that's our, you know in your initial idea, right?
+
+Andrew Brown: Yeah, it should, right? Yeah.
+
+hydai: Yeah. Yeah, yeah. Yeah. So. So.
+
+Andrew Brown: Yeah.
+
+hydai: So yeah, and yeah, so.
+
+Andrew Brown: And there's been a lot of work there to speed things up, like, for example, one of
+those projects I looked at, it talks about trying to speed up inference on xeons. Right. And so we
+already know that running stuff on GPU can be heavily optimized in certain cases. But sometimes if
+you just wanna run it on the CPU itself and you have a large enough server like going down one of
+these routes is it's worth investigating, right? Rather than buying a bunch of expensive new
+hardware so. Yeah. Make I understand where you're coming from on this. We'll probably there's
+probably more more thinking to be done in this area. Any other questions for Heidi or any other
+comments that we wanna bring up before we close? Alright. Well, I will take the transcript. Put it
+into the meeting notes. I'll put some of the links here that Heidi you've posted. Umm. And I'll see
+you guys next time.
+
+hydai: Bye bye.
+
+Mingqiu Sun: Yeah.
+
+Andrew Brown: I.
+
+Johnnie L Birch Jr: Yeah. Thank you.
+
+Mingqiu Sun: Thank you. OK, bye.
+

--- a/machine-learning/2024/ML-06-24.md
+++ b/machine-learning/2024/ML-06-24.md
@@ -1,0 +1,20 @@
+# Wasm+ML Working Group &mdash; June 24
+
+See the [instructions](../README.md) for details on how to attend.
+
+### Agenda
+
+1. Opening, welcome and roll call
+    1. Please help take notes &mdash; thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Proposals and discussions
+    1. _Submit a PR to add your announcement here_
+
+### Attendees
+
+- _Fill in after meeting_
+
+### Notes
+
+_Fill in after meeting_


### PR DESCRIPTION
Creating all the elements needed to enable SIG Embedded meeting announcements, agenda development, and publishing of meeting minutes.  The first official meeting is still to be scheduled via discussion on Zulip, with details to be provided here in a future update.