### PR TITLE
TSC minutes for June 11, 2024

### DIFF
--- a/TSC/2024/tsc-06-11.md
+++ b/TSC/2024/tsc-06-11.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** June 11, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneiderreit  
+
+**Others present:**  
+David Bryant, Secretary (note taker)
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, including the formation of new Special Interest Groups, consideration of projects for Hosted or Core Project status, and ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed.   
+
+### Topic #2
+With the formal approval to begin operation of SIG Embedded and SIG Packaging, David took action items to work with the acting chairs of each group respectively to announce and host their first meetings.  
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:07am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes for the June 11, 2024 TSC meeting.