### PR TITLE
Publishing TSC meeting minutes for June 18, 2024

### DIFF
--- a/TSC/2024/tsc-06-18.md
+++ b/TSC/2024/tsc-06-18.md
@@ -4,7 +4,7 @@
 **Time:** 10:00am PT  
 **Place:**	By online video conference  
 
-**TSC Members present:**
+**TSC Members present:**  
 Bailey Hayes  
 Nick Fitzgerald  
 
@@ -26,5 +26,5 @@ Plans for the release of WASI 0.2.1 were discussed, including timing/schedule, f
 ### Adjournment
 There being no other business to come before the meeting, it was adjourned at approximately 10:59am PT
 
-David Bryant
+David Bryant  
 Secretary of the meeting

--- a/TSC/2024/tsc-06-18.md
+++ b/TSC/2024/tsc-06-18.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** June 18, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**
+Bailey Hayes  
+Nick Fitzgerald  
+
+**Others present:** 
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, and ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed.
+
+### Topic #2
+With the recent launch and change in status of several new Special Interest Groups, the TSC reviewed operational needs for those groups and improvements to procedures involved in supporting them.
+
+### Topic #3
+Plans for the release of WASI 0.2.1 were discussed, including timing/schedule, functional content, and proper delivery of a incremental release relative to the existing 0.2 version.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:59am PT
+
+David Bryant
+Secretary of the meeting


### PR DESCRIPTION
Publishing approved minutes from the June 18, 2024 Technical Steering Committee meeting.