### PR TITLE
Publish 25-Jun-2024 TSC minutes

### DIFF
--- a/TSC/2024/tsc-06-25.md
+++ b/TSC/2024/tsc-06-25.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** June 25, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**   
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interrest Group activities, and ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed.
+
+### Topic #2
+TSC members observed that a recurring topic in a variety of recent project and Alliance member conversations has been in connecting knowledgeable resources with opportunities to contribute. Ideas were shared as to how the Alliance could help make those connections happen appropriately through efforts of the TSC and Board, and in enabling projects and members to share their interests.
+### Topic #3
+
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:54am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Adding meeting minutes for the June 25, 2024 TSC meeting to our public repository of meeting materials.