### PR TITLE
TSC minutes for July 16, 2024

### DIFF
--- a/TSC/2024/tsc-07-16.md
+++ b/TSC/2024/tsc-07-16.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** July 16, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Nick Fitzgerald   
+Till Schneidereit  
+
+**Others present:**   
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interrest Group activities, and ongoing standards discussions within the W3C Community Group. Of particular interest was furthering efforts by the TSC to finalize Core Project requirements. Proper follow-up actions will be taken by reviewers on the requests discussed. 
+
+### Topic #2
+Till recapped a discussion at last week's Bytecode Alliance Board meeting regarding clarifying requirements for serving as co-chair of a Special Interest Group, including specific steps to be taken to incorporate those requirements in the TSC charter and to update current SIG chairs.
+
+### Topic #3
+David highlighted a few operational topics of interest, including recent onboarding of analytics tools for the Alliance website and information from GitHub that the Alliance's current organizational account would be automatically upgraded to a new type, with some attendant administrative changes, on September 3rd.
+
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:04am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the Technical Steering Committee (TSC) on Tuesday, July 16 2024.