### PR TITLE
TSC minutes for Aug 6, 2024

### DIFF
--- a/TSC/2024/tsc-08-06.md
+++ b/TSC/2024/tsc-08-06.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 6, 2024  
+**Time:** 10:00am PT  
+**Place:**	By online video conference  
+
+**TSC Members present:**  
+Nick Fitzgerald  
+Bailey Hayes  
+
+**Others present:**  
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interrest Group activities, and ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. 
+
+### Topic #2
+Given limited attendance today, the TSC deferred continued discussion of `rustwasm` and related project maintainance to next week's meeting (continuing from last week).
+
+### Topic #3
+The TSC discussed this week's WASI 0.2.1 release and expectations for future releases in accordance with the regular bi-monthly schedule established by the WASI project.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:42am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish Technical Steering Committee (TSC) meeting minutes for August 6, 2024.