### PR TITLE
Publish TSC minutes for Aug 13, 2024

### DIFF
--- a/TSC/2024/tsc-08-13.md
+++ b/TSC/2024/tsc-08-13.md
@@ -1,0 +1,37 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 13, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interrest Group activities, and ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. 
+
+**Action:** David and Till will follow up in processing nominations received for Recognized Contributor.
+
+### Topic #2
+The TSC continued discussion from last week's meeting of adopting relevant GitHub projects being discontinued by the `rustwasm` organization, agreeing that projects to be considered should be identified out through pull requests that would enable TSC review and public discussion.  There was also review of current TSC governance, confirming it allows consideration of maintenance status both in adopting new hosted projects and in reviewing hosted projects at any time.
+
+### Topic #3
+The TSC agreed to review a draft announcement for the proposed Plumbers Summit event and provide feedback (via Zulip).
+
+### Topic #4
+David shared a alert received from Zoom regarding public sharing of meeting access credentials, which the TSC discussed in consideration of best practices to be suggested to SIGs and other public Alliance technical working groups.
+
+**Action:** David will follow up with each SIG to review their sharing of Zoom meeting credentials and propose any changes needed.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:06am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Adding minutes from the August 13, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC) .