### PR TITLE
TSC minutes for August 20, 2024

### DIFF
--- a/TSC/2024/tsc-08-20.md
+++ b/TSC/2024/tsc-08-20.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 20, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interrest Group activities, and ongoing standards discussions within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. Starling Monkey was approved as a new Hosted Project. Pending Recognized Contributor nominations have been fully processed, including confirming with the new RCs.
+
+### Topic #2
+The TSC followed up on offline discussion regarding a proposed update to the Alliance Code of Conduct, per Till's action item from last week's TSC meeting. 
+
+**Action:** David and Till will produce a revised CoC, including updating to the latest version of the Contributor Covenant.
+
+### Topic #3
+David provided an update on planning efforts for the Plumbers Summit event.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:48am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes for the August 20, 2024 meeting of the Technical Steering Committee (TSC).