### PR TITLE
Publish TSC minutes for August 27, 2024

### DIFF
--- a/TSC/2024/tsc-08-27.md
+++ b/TSC/2024/tsc-08-27.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 27, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards activities within the W3C Community Group. Core Project Requirements have advanced and are ready to be published.  Proper follow-up actions will be taken by reviewers on the requests discussed. There was discussion of phases of activity implied by ongoing project work and the anticipated evolution of WebAssembly, and which represent relevant agenda topics for the upcoming Plumbers Summit.
+
+### Topic #2
+The TSC continued the discussion of an update to the Alliance Code of Conduct, including feedback from last week's BA board meeting regarding the review and approval process. 
+
+**Action:** David and Till will arrange legal review of the draft CoC update prior to presenting it to the TSC and board for approval.
+
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:07am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes for the August 27, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).