### PR TITLE
Publish Sept 9, 2024 TSC minutes

### DIFF
--- a/TSC/2024/tsc-09-03.md
+++ b/TSC/2024/tsc-09-03.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 3, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards activities within the W3C Community Group. Core Project requirements reviews are being scheduled with selected projects to solicit feedback on the requirements, and on the process and timeline for using them to identify Core Projects. Proper follow-up actions will be taken by reviewers on the requests discussed.
+
+### Topic #2
+David provided an update on ongoing planning for the proposed September Plumbers Summit event, for which the planning team has received enough in-person RSVPs to enable holding the meeting in person as well as online. 
+
+### Topic #3
+David, Bailey and Till recapped a recent meeting with representatives from IMEC regarding their proposal for the Bytecode Alliance to host an academic workshop at an upcoming IEEE conference. Additional debrief and further discussion will happen at the next Alliance board meeting.
+
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:58am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes for the September 3, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).