### PR TITLE
Publish TSC minutes for September 10, 2024

### DIFF
--- a/TSC/2024/tsc-09-10.md
+++ b/TSC/2024/tsc-09-10.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 10, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Nick Fitzgerald  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards activities within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. Project specific reviews of Core Project requirements have begun, providing feedback to the TSC on those requirements as well as helping refine the process for using them to assess formal compliance.
+
+**Action:** TSC members will review the requirements feedback and use next week's meeting to agree on modifications that should be made.
+
+### Topic #2
+Bailey shared a review draft proposal for creation of a new Special Interest Group to be focused on engaging with and supporting WebAssembly related efforts of academic researchers and organizations. TSC members were asked to provide comments in anticipation of the proposal being submitted for adoption.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:56am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes from the September 10, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).