### PR TITLE
TSC minutes, September 17 2024

### DIFF
--- a/TSC/2024/tsc-09-17.md
+++ b/TSC/2024/tsc-09-17.md
@@ -1,0 +1,36 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 17, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards activities within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. Project specific reviews of Core Project requirements are continuing, providing feedback to the TSC on those requirements as well as helping refine the process for using them to assess formal compliance.
+
+**Action:** Nick will publish an update to the Core Project Requirements template based on project feedback thus far, for ongoing use with candidate projects.
+
+### Topic #2
+Bailey collected TSC feedback on her draft SIG Research proposal, and should be in a position to submit it for formal review soon.
+
+### Topic #3
+The TSC discussed compatibility and alignment between WASI 0.2 and ongoing work towards a follow-on 0.3 release. More discussion of this topic is anticipated in the future as work continues across various projects.
+
+### Topic #4
+Next week's TSC meeting (September 24) will be canceled given member schedule conflicts including travel to arrive for in-person participation at next week's Plumbers Summit event.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:02am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes from the September 17, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).  Note there will be no TSC meeting on September 24.