### PR TITLE
TSC minutes for October 1, 2024

### DIFF
--- a/TSC/2024/tsc-10-01.md
+++ b/TSC/2024/tsc-10-01.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** October 1, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards activities within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. Discussion recapped progress from a core project requirements review meeting last week with representatives of the WAMR team, based on the updated requirements template. More such discussions are planned.
+
+
+### Topic #2
+David solicited feedback on last week's two-day Plumbers Summit event, in part to help us better plan a future Summit.  Session recordings are being prepared for sharing publicly. 
+
+### Topic #3
+The TSC brainstormed ways to identify and encourage updates to the News page on the Alliance website, given the growing range of activity across projects and SIGs and the benefits of highlighting relevant content published elsewhere through those project efforts.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:00am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the October 1, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).