### PR TITLE
TSC minutes for 8 October 2024

### DIFF
--- a/TSC/2024/tsc-10-08.md
+++ b/TSC/2024/tsc-10-08.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** October 8, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards activities within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests discussed. Discussion continued regarding ongoing review of core project requirements with representatives of the WAMR team, most recently based on the team's written summary of status on a per-requirement basis.
+
+
+### Topic #2
+David shared an initial draft of the timeline and plan for the Alliance's December 2024 election, which includes selection of seats on the TSC. The plan will be presented for Board review at the October 17 meeting.
+
+### Topic #3
+The TSC discussed potentially newsworthy posts that could be developed for publication on the Alliance webb site, identifying two possibilities that could be arranged in the near term (including one by David recapping the recent Plumbers Summit event).
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:03am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes for the October 8, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).