### PR TITLE
TSC meetings for Oct 15, 2024

### DIFF
--- a/TSC/2024/tsc-10-15.md
+++ b/TSC/2024/tsc-10-15.md
@@ -1,0 +1,27 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** October 15, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. Discussion of the potential benefit of security audits and standards compliance reviews to projects under consideration for Core Project status led to adding that topic to the agenda for this week's Alliance Board meeting.  Progress made in Core Project requirements reviews with the WAMR team support being able to move ahead in publishing those requirements to the Alliance governance repository.
+
+### Topic #2
+David shared that the NOMS conference has accepted our proposal for an academic workshop as part of their May 2025 conference.  Next steps include finalizing details with the conference committee and publishing the workshop Call for Papers.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:00am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish meetings for the Technical Steering Committee (TSC) from its meeting on October 15, 2024.