### PR TITLE
TSC minutes for October 22, 2024

### DIFF
--- a/TSC/2024/tsc-10-22.md
+++ b/TSC/2024/tsc-10-22.md
@@ -1,0 +1,26 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** October 22, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. Bailey provided an update on conversations with SIG-Packaging regarding the roadmap for warg. Follow up to the recent board meeting discussion of security audits and standards compliance reviews for candidate Core Projects helped identify some next steps TSC could take to provide a more concrete proposal for board review.
+
+### Topic #2
+David requested review and feedback on the current Recognized Contributors mailing list in preparation for using it to organize our upcoming Elected Delegate and At-Large Director elections.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:00am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the October 22, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).