### PR TITLE
TSC minutes for October 29, 2024

### DIFF
--- a/TSC/2024/tsc-10-29.md
+++ b/TSC/2024/tsc-10-29.md
@@ -1,0 +1,27 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** October 29, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. 
+
+### Topic #2
+The TSC agreed to delay announcement of the upcoming Elected Delegate and At-Large Director election until November 5 to allow completion of pending nominations for Recognized Contributor status. The call for nominees will still go out as planned on November 11.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:03am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the October 29, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).