### PR TITLE
Publish TSC minutes for November 5, 2024

### DIFF
--- a/TSC/2024/tsc-11-05.md
+++ b/TSC/2024/tsc-11-05.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** November 5, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. 
+
+### Topic #2
+David reviewed current status of nominations for new Recognized Contributors, with TSC members highlighting additional nominations they proposed to make. After discussion, it was decided that nominations should be submitted by Thursday, Noevmeber 7 so they could be reviewed and approved in time to be included in upcoming election announcements that will begin on Friday, November 8.
+
+## Topic #3
+Next week several TSC members will be attending WasmCon 2024, which overlaps the regular Tuesday, 10am PT meeting time. It was decided to conduct TSC business on-line via Zulip and GitHub next week to maintain the pace of progress but also adapt to the time conflict WasmCon represents.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:48am PT
+
+David Bryant  
+Secretary of the meeting

--- a/TSC/2024/tsc-11-05.md
+++ b/TSC/2024/tsc-11-05.md
@@ -20,7 +20,7 @@ The TSC reviewed current governance topics as identified across issues and pull 
 ### Topic #2
 David reviewed current status of nominations for new Recognized Contributors, with TSC members highlighting additional nominations they proposed to make. After discussion, it was decided that nominations should be submitted by Thursday, Noevmeber 7 so they could be reviewed and approved in time to be included in upcoming election announcements that will begin on Friday, November 8.
 
-## Topic #3
+### Topic #3
 Next week several TSC members will be attending WasmCon 2024, which overlaps the regular Tuesday, 10am PT meeting time. It was decided to conduct TSC business on-line via Zulip and GitHub next week to maintain the pace of progress but also adapt to the time conflict WasmCon represents.
 
 ### Adjournment


### PR DESCRIPTION
Publishing minutes for the November 5, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC)