### PR TITLE
TSC minutes for 19 November 2024

### DIFF
--- a/TSC/2024/tsc-11-19.md
+++ b/TSC/2024/tsc-11-19.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** November 19, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  Note: There was no formal TSC meeting last week due to WasmCon travel and commitments, with the TSC handling important business asynchronously.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. With Core Project requirements having been approved and published, next step conversations can be arranged with the WAMR and Wasmtime project teams as well as in creating a blog post to highlight publication of those requirements.
+
+### Topic #2
+David reviewed current status of nominations for new Recognized Contributors, with the TSC providing approval and taking additional steps where appropriate. David will engage with newly approved RCs to bring them up to date on the December election cycle now that it is underway.
+
+### Topic #3
+The TSC shared ideas on working meetings to be scheduled in support of the WASI Preview 3 roadmap and deliverables including a likely Plumbers Summit, additional time at the February WASM Community Group in-person meeting, and adjacent to the Wasm.io conference in late March. This topic will be revisited at the next TSC meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:58am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the November 19, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).