### PR TITLE
TSC minutes for 26 November, 2024

### DIFF
--- a/TSC/2024/tsc-11-26.md
+++ b/TSC/2024/tsc-11-26.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** November 26, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. Core project requirements assessment efforts continue with both WAMR and Wasmtime project teams.
+
+### Topic #2
+David provided an update on the ongoing election process. Additional Recognized Contributors are being included as they are approved so they may both nominate and vote in the December election.
+
+### Topic #3
+Continuing a discussion from last week's meeting, the TSC converged around a working plan for meetings to be arranged in support of the WASI Preview 3 roadmap and deliverables. Steps will be taken to arrange a detailed planning meeting the week of December 9th, and further study done to assess feasibility of a two-day in-person working session ("Plumbers Summit") co-located with the Wasm I/O conference in late March. 
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:50am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the November 26, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).