### PR TITLE
Publish TSC minutes for Dec 3, 2024

### DIFF
--- a/TSC/2024/tsc-12-03.md
+++ b/TSC/2024/tsc-12-03.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** December 3, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. Core project requirements assessment efforts continue with both WAMR and Wasmtime project teams.
+
+### Topic #2
+David provided an update on the ongoing election process. Nominations closed yesterday, with formal announcement of candidates who accept their nominations to happen by the end of the day this Friday.
+
+### Topic #3
+Due to a lack of time, continuing discussion about WASI Preview 3 planning meetings will take pace off-line, including steps necessary to organize an initial working meeting in December. 
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:05am PT
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Sharing minutes from the December 3, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).