### PR TITLE
Publish TSC meeting minutes 10Dec2024

### DIFF
--- a/TSC/2024/tsc-12-10.md
+++ b/TSC/2024/tsc-12-10.md
@@ -1,0 +1,40 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** December 10, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. A Core Project requirements template has been submitted for review by the Wasmtime project. A new Hosted Project proposal for building well-formed sample components in multiple guest languages has been received for consideration.
+
+### Topic #2
+The TSC discussed potential conflict of interest aspects arising from formal review of the Wasmtime Core Project proposal by the TSC when two of three current TSC members are closely affiliated with the Wasmtime project and contributed to the submitted proposal. Having anticipated this concern, Bailey has kept herself wholly apart from creation of the proposal so she might review it with an independent perspective once submitted (and therefore public). The TSC agreed to raise this topic with the Alliance Board.
+
+**Action:** Bailey will, now that the proposal has been submitted, provide a review for sharing with the Board, TSC, and through public feedback.
+
+**Action:** Till will raise this issue for discussion at this week's Bytecode Alliance Board meeting.
+
+### Topic #3
+David provided an update on the ongoing election process. Nominees have been announced to the RC mailing list and balloting begun through CIVS.  Voting closes at midnight US Pacific Time on December 22.
+
+### Topic #4
+Recent receipt of a security issue via the security reporting mailing list prompted discussion of a more thorough approach to soliciting such issues as well as following up on them appropriately with projects involved. The TSC agreed a better approach would be to employ GitHub issues and project visibility there. This will be carried over as a work item for the newly elected TSC when it is installed in January 2025.
+
+**Action:** David will raise this issue for attention when the reconstituted TSC first meets in January.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:05am PT. As part of the adjournment discussion the TSC decided to cancel meetings scheduled for December 24 and 31, making the next meeting on December 17 the last TSC meeting of the year (and the current TSC).
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish meeting minutes from the December 10, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC)