### PR TITLE
Publish TSC meeting minutes for 17 Dec 2024

### DIFF
--- a/TSC/2024/tsc-12-17.md
+++ b/TSC/2024/tsc-12-17.md
@@ -1,0 +1,34 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** December 17, 2024  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Nick Fitzgerald  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including on the Wasmtime Core Project proposal.
+
+### Topic #2
+The TSC discussed feedback received from last week's Alliance Board meeting on concerns raised regarding potential conflict of interest in TSC review of the Wasmtime Core Project proposal. The Board observed that the TSC charter assigns designation of Core Project status to the Board, decoupling that action from the review and acceptance carried out by the TSC. As such the Board was comfortable with the steps proposed by the TSC in handling the Wasmtime review, including but not limited to public discussion of the TSC's findings and an open comment period.
+
+### Topic #3
+Bailey summarized progress on her creation of a draft statement of scope for Alliance participation in the OpenSSF foundation, per an action item from last week's Alliance Board meeting. She plans to complete that work for TSC review, and will transition ownership to the newly elected TSC when it begins operation in January 2025.
+
+### Topic #4
+David provided an update on the ongoing election process. Fifty-one ballots have been cast thus far. Voting closes at midnight US Pacific Time on December 22. The TSC discussed ways to effectively onboard newly elected members in January and provide continuity in ongoing efforts.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:04am PT. As noted previously, this meeting was the last TSC meeting in 2024.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish meeting minutes from the December 17, 2024 meeting of the Bytecode Alliance Technical Steering Committee (TSC).   As noted in the minutes, this is the last scheduled meeting of the TSC in 2024.