### PR TITLE
TSC minutes for January 21, 2025

### DIFF
--- a/TSC/2025/tsc-01-21.md
+++ b/TSC/2025/tsc-01-21.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** January 21, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including review of the WAMR Core Project proposal.
+
+### Topic #2
+Oscar Spencer was selected as TSC Director, representing the TSC on the Alliance Board.  Andrew Brown was selected as TSC Chair. Both will begin serving immediately.
+
+### Topic #3
+TSC members summarized their reviews of the Wasmtime Core Project Proposal per their action items from last week's meeting. Each identified concerns needing to be resolved in collaboration with the Wasmtime team, agreeing to provide those comments as issues on the submitted proposal. After discussion, the TSC voted to recognize Wasmtime as a Core Project pending resolution of the identified issues as well as presentaiton of its findings for approval at this week's Alliance Board meeting. The review process also identified several clarifications to be made to the Core Project requirements, which will be addressed as updates to the template.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:02pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing meeting minutes for the January 21, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).