### PR TITLE
wasmtime: add p3 crate organization to agenda

### DIFF
--- a/wasmtime/2025/wasmtime-01-30.md
+++ b/wasmtime/2025/wasmtime-01-30.md
@@ -14,6 +14,7 @@
 1. Other agenda items
    1. Mendy Berger: Discuss adding wasi-gfx support in Wasmtime.
    1. Alex Crichton: Extending MSRV/Security bugfix windows - https://github.com/bytecodealliance/wasmtime/issues/10074
+   1. Roman Volosatovs: WASI crate organization for p3 work
    1. _Submit a PR to add your item here_
 1. Issue Triage
    * [New, Untriaged Issues](https://github.com/bytecodealliance/wasmtime/issues?q=is%3Aopen+comments%3A%3C2+created%3A%3E%3D2024-12-19)


### PR DESCRIPTION
I'd like to discuss the proposal I briefly laid out in https://github.com/bytecodealliance/wasmtime/pull/10073#issuecomment-2615559720