### PR TITLE
TSC minutes for Jan 28, 2025

### DIFF
--- a/TSC/2025/tsc-01-28.md
+++ b/TSC/2025/tsc-01-28.md
@@ -1,0 +1,33 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** January 28, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+### Topic #2
+Oscar reported that the Alliance board reviewed and voted to approve the TSC's recommendation that Wasmtime be adopted as a Core Project. TSC members will follow up with the Wasmtime project team to notify them officially and work to make appropriate updates in Alliance and project materials (including the Alliance website).
+
+**Action:** Oscar will update the Core Project proposal template to reflect improvements identified over the course of the Wasmtime project review.
+
+### Topic #3
+TSC members identified a number of topics to be addressed in upcoming meetings, and to use the TSC rolling meeting agenda document to accumulate additional such topics as they may arise between meetings.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:06pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the January 28, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).