### PR TITLE
TSC minutes for Feb 4, 2025

### DIFF
--- a/TSC/2025/tsc-02-04.md
+++ b/TSC/2025/tsc-02-04.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** February 4, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. Oscar recapped having attended the Wasmtime project meeting to relay news of Board approval of its Core Project status.
+
+### Topic #2
+TSC members shared perspectives on how the overall portfolio of Alliance projects might be reviewed on an ongoing basis to identify needed services or resources, appropriately align project efforts with overall usage across the community, and where needed to archive projects (as has been necessary from time to time). The discussion also highlighted a request from SIG-Documentation to collaborate on maintaining a public roadmap for selected projects. 
+
+### Topic #3
+There will be no TSC meeting next week (February 11) due to the Wasm Community Group in-person meeting.  The next TSC meeting will be on February 18.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:06pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the February 4, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).