### PR TITLE
TSC minutes for 18-Feb-2025

### DIFF
--- a/TSC/2025/tsc-02-18.md
+++ b/TSC/2025/tsc-02-18.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** February 18, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon. As an operational note, the February 11 TSC meeting was canceled to allow members to attend the WebAssembly Community Group meeting that week.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed. Three new Recognized Contributors were approved, as was a draft blog post recapping 2024 highlights for the WAMR project.
+
+### Topic #2
+Oscar provided an update on his work to draft guidance from the TSC clarifying the types of projects that would be considered good candidates for Core Project status, as requested by the Alliance board.  
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:04pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the February 18, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).