### PR TITLE
Publish TSC minutes for February 25, 2025

### DIFF
--- a/TSC/2025/tsc-02-25.md
+++ b/TSC/2025/tsc-02-25.md
@@ -1,0 +1,33 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** February 25, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+**Action:** David will draft draft for review a short position statement reflecting today's TSC discussion clarifying Hosted Project status as applies to the overall portfolio of Alliance projects.
+
+### Topic #2
+The TSC discussed an action item it received from the Alliance board asking for a high-level summary of needs for improved fuzzing and compiliance testing of Alliance projects, reviewing in doing so an initial enumeration Bailey provided. As a follow up, conversations will happen with project teams in an effort to revise and refine the working list and enable timely follow-up with the board  
+
+### Topic #3
+The TSC reviewed its list of open action items and ongoing work efforts.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:52am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publishing minutes from the February 25, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).