### PR TITLE
TSC minutes for March 4, 2025

### DIFF
--- a/TSC/2025/tsc-03-04.md
+++ b/TSC/2025/tsc-03-04.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** March 4, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+### Topic #2
+The TSC reviewed progress in its ongoing effort to survey project needs for improved fuzzing and compliance testing. Bailey walked members through an analysis she has prepared reflecting those investigations, including current scoping of effort for work that might be undertaken with incremental investment through the Alliance. An update is being prepared for sharing with the Alliance board at their meeting this Thursday.
+
+### Topic #3
+The TSC reviewed its list of open action items and ongoing work efforts. David collected feedback on his draft statement of the TSC's approach to managing Hosted Projects.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:05pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the March 4, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).