### PR TITLE
TSC minutes for March 11, 2025

### DIFF
--- a/TSC/2025/tsc-03-11.md
+++ b/TSC/2025/tsc-03-11.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** March 11, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+### Topic #2
+Oscar's update at last week's Alliance board meeting on ongoing TSC investigation of outsourced compliance test development resulted in an action item for the TSC to solicit proposals for further review. David reported that he has begun that process and will work with Andrew to engage vendors interested in the opportunity.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:12pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the March 11 meeting of the Bytecode Alliance Technical Steering Committee (TSC)