### PR TITLE
TSC minutes for March 18, 2025

### DIFF
--- a/TSC/2025/tsc-03-18.md
+++ b/TSC/2025/tsc-03-18.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** March 18, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Oscar Spencer  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC welcomed Till Schneidereit as its newest member. Till was selected by the Wasmtime project as its Appointed TSC Delegate, now that Wasmtime has been approved as a Bytecode Alliance Core Project. Welcome Till!
+
+### Topic #2
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+### Topic #2
+David and Andrew shared that they have begun reaching out in search of vendors capable of and interested in development of conformance test suite(s) for Alliance projects. They expect to begin meeting with responding vendors this week and will provide an update for the TSC at next week's meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:48am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the March 18, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC)