### PR TITLE
TSC minutes for March 25, 2025

### DIFF
--- a/TSC/2025/tsc-03-25.md
+++ b/TSC/2025/tsc-03-25.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** March 25, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+### Topic #2
+Andrew, Bailey and David reported on their first meeting with a vendor interested in contracted development of conformance test suite(s) for Alliance projects. The meeting provided sufficient context that the vendor has offered to detail a variety of approaches to the effort and provide initial guidance on timeframes in which the work might be done. A follow-on meeting is expected as soon as the vendor informs us they have that information to share.
+
+### Topic #3
+David reported some changes in the co-chairs and operation of Alliance Special Interest Groups such that they should be reflected in updates to general SIG information in the Alliance governance repository. Follow-up conversation will happen in the TSC Zulip channel on specific mentions to be made (which David will handle).
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:38am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the March 25, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).