### PR TITLE
TSC minutes for April 1, 2025

### DIFF
--- a/TSC/2025/tsc-04-01.md
+++ b/TSC/2025/tsc-04-01.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 1, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed.
+
+### Topic #2
+David reported he's reached out for an update from the vendor for an update on next steps regarding compliance testing development possibilities and expects to work with them to arrange a follow-up meeting as soon as they are ready to discuss their ideas.
+
+### Topic #3
+In the interest of time, David agreed to share via Zulip his proposal for an update to public-facing information on current Alliance SIG operations. Feedback and approval will be solicited there, to be recapped at the next TSC meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:38am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the April 1, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).