### PR TITLE
TSC minutes for April 8, 2025

### DIFF
--- a/TSC/2025/tsc-04-08.md
+++ b/TSC/2025/tsc-04-08.md
@@ -1,0 +1,33 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 8, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Oscar Spencer  
+Till Schneiderent  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+The TSC discussed the preliminary response received from our initial vendor on the proposed compliance testing development project, agreeing that sufficient information was included to allow providing an update for Board review at the April 17 meeting. David will reply to the vendor updating them as to that next step.
+
+### Topic #3
+Till provided an update on preparations under way to formally announce Wasmtime as Core Project.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:02am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the April 8, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).