### PR TITLE
TSC minutes for April 15, 2025

### DIFF
--- a/TSC/2025/tsc-04-15.md
+++ b/TSC/2025/tsc-04-15.md
@@ -1,0 +1,33 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 15, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Oscar Spencer  
+Till Schneiderent  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+Recent discussions with various Alliance project teams has highlighted ways the TSC might provide helpful guidance for those projects and also suggest best practices projects could find useful. The TSC discussed ways to capture, publish, and evolve information for projects as part of the existing governance repository, much as has been done previously in supporting establishment of Special Interest Groups. Options discussed will be shared for feedback with projects, allowing a specific approach to be identified at a future TSC meeting.
+
+### Topic #3
+Oscar will share current status of the compliance testing development project investigation at this week's Alliance board meeting, soliciting feedback on next steps and areas of interest.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:56am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the April 15, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).