### PR TITLE
TSC minutes for April 22, 2025

### DIFF
--- a/TSC/2025/tsc-04-22.md
+++ b/TSC/2025/tsc-04-22.md
@@ -1,0 +1,36 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 22, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Oscar Spencer  
+Till Schneiderent  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+Drawing on recent converations with project teams, Oscar asked if the Alliance had considered establishing formal guidance on the use of AI and generative content.  TSC members shared perspectives based on similar experiences and pointed out as examples how some other organizations approached governing use of AI. Members agreed to consider the topic for possible future follow up and be alert for relevant instances as may arise in the meantime.
+
+### Topic #3
+Oscar shared a draft communications policy as his action item from last week's brainstorming meeting. TSC Members provided feedback, allowing Oscar to update the draft so he can next submit it as a PR for formal review and publication.
+
+### Topic #4
+In the interest of time, David highlighted two agenda topics for off-line review and follow-up in next week's meeting -- prioritizing compliance testing development efforts and review of Alliance security process mechanisms, both in response to requests from the Board.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:06pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the April 22, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).