### PR TITLE
Publish TSC minutes for April 29, 2025

### DIFF
--- a/TSC/2025/tsc-04-29.md
+++ b/TSC/2025/tsc-04-29.md
@@ -1,0 +1,35 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 29, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Till Schneiderent  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+David recapped offline feedback on his notes summarizing current Alliance project security operations, indicating he'd received sufficient guidance that his next step would be to provide a draft of revisions that could be made to enhance overall consistency and ongoing maintenance.
+
+### Topic #3
+TSC members discussed next steps in the ongoing assessment of conformance testing development options, including feedback from the Alliance board, agreeing it would be appropriate to reconvene with the involved third party vendor and revisit both the timeline and primary motiviations for the project.  David will work to arrange that meeting.
+
+### Topic #4
+Till solicited final comments on an article for the Alliance blog announcing Wasmtime's promotion to Core Project status.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:08pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the April 29, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).