### PR TITLE
Publish May 6, 2025 TSC minutes

### DIFF
--- a/TSC/2025/tsc-05-06.md
+++ b/TSC/2025/tsc-05-06.md
@@ -1,0 +1,33 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 6, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Till Schneiderent  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. TSC reviewed and approved publication of a contributor-authored blog post for the Alliance website.
+
+### Topic #2
+TSC members provided feedback on David's proposed security operations summary document, allowing it to be retained as a reference for current and future Executive Directors. It will also be shared with the Alliance board per their request to the TSC.
+
+### Topic #3
+TSC members debriefed from the recent candidate vendor meeting reviewing progress in exploring conformance test development. The next step will be to assess project development options to be suggested by the vendor as a follow up from that meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:10pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the May 6, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).