### PR TITLE
TSC minutes for May 20, 2025

### DIFF
--- a/TSC/2025/tsc-05-20.md
+++ b/TSC/2025/tsc-05-20.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 20, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Till Schneiderent  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon. As a note, last week's TSC meeting (May 13) was canceled do to member schedule conflicts.
+
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group.  TSC members observed that the WAMR project had published its pending CVE and provided an update release incorporating the associated fix. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+THe TSC discussed a Zulip post from the author of the zig-wasmtime project suggesting that it be considered for adoption as a Hosted Project. Oscar will follow up to point the author to our Hosted Project requirements as the way to make such a proposal formally.
+
+### Topic #3
+The contributed and reviewed blog post on running WebAssembly components from the command line will be published (via formal TSC approval) coincident with the release of Wasmtime v33 on May 21.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:02pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the May 20, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).