### PR TITLE
TSC minutes for 27 May 2025

### DIFF
--- a/TSC/2025/tsc-05-27.md
+++ b/TSC/2025/tsc-05-27.md
@@ -1,0 +1,27 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 27, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Steps are being taken with the WAMR team to announce their recent security release via the Alliance's public mailing list and complete the security advisory resolution process. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+Recent work by the jco project team to automate their releases and properly manage the associated credentials led to a general discussion of current Alliance credential management processes shared across SIGs and projects. No follow on actions were identified.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:43am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the May 27, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).