### PR TITLE
Publish TSC minutes for June 3, 2025

### DIFF
--- a/TSC/2025/tsc-06-03.md
+++ b/TSC/2025/tsc-06-03.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** June 3, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Oscar Spencer  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. The WAMR project announced their security update on the Alliance mailing list and an overall debrief is being scheduled to highlight lessons learned. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+The TSC received a revised compliance testing project high-level proposal from the candidate vendor, which will be reviewed offline and discussed in detail at next week's TSC meeting such that a follow-up discussion with the vendor can be arranged.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:06pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the June 3, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).