### PR TITLE
TSC minutes for June 17, 2025

### DIFF
--- a/TSC/2025/tsc-06-17.md
+++ b/TSC/2025/tsc-06-17.md
@@ -1,0 +1,35 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** June 17, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Oscar Spencer  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon. As an operational note, there was no TSC meeting on June 10 due to member availability with pending business handled online.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. The WAMR project announced their security update on the Alliance mailing list and an overall debrief is being scheduled to highlight lessons learned. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+Till provided an update on "BigGo" support as an aspect of ongoing guest language support for Go with WASI Preview 2, highlighting progress as well as issues encountered as also reported via a public pull request.
+
+### Topic #3
+Oscar led a discussion of hosted/core project maintenance requirements, highlighting current needs in several projects. TSC members shared their observations on specific project circumstances including number of active maintainers, timely response to issues and PRs, effective handling of project releases, and administration of repositories. Each case included contemplation of TSC supporting activities that could pro-actively identify needs as they arise and also respond effectively to requests from projects and contributors. This topic will be revisited at the next TSC meeting in pursuit of specific policies and actions TSC should implement.
+
+### Topic #3
+Based on offline conversations, the TSC agreed the next step in pursuit of vendor supplied compliance testing would be for the vendor to submit a formal Statement of Work based on the preliminary proposal already received. David has communicated that next step to the vendor.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:02pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the June 17, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).