### PR TITLE
TSC minutes for June 24, 2025

### DIFF
--- a/TSC/2025/tsc-06-24.md
+++ b/TSC/2025/tsc-06-24.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** June 24, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Oscar Spencer  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. The WAMR project CVE debrief has been scheduled for June 26. A Code of Conduct enforcement question was reviewed. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #3
+TSC members shared their comments on the draft compliance testing Statement of Work received from the vendor, agreeing it would be appropriate to present it for review at this week's Bytecode Alliance Board meeting. 
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:01pm PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the June 27, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).