### PR TITLE
Publish TSC meeting minutes for July 1, 2025

### DIFF
--- a/TSC/2025/tsc-07-01.md
+++ b/TSC/2025/tsc-07-01.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** July 1, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Oscar Spencer  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+The Alliance Board approved the compliance test development project at its June 26th meeting, and as follow-up David shared that he has been working to schedule a project kick-off meeting with the right technical participants and to finalize the formal agreement with the vendor in partnership with Alliance legal counsel.
+
+### Topic #3
+TSC members shared ideas about improving community participation on the Alliance Zulip chat server, including possible regional discussion groups, server administration changes to handle Code of Conduct concerns, and improved mechanisms for TSC engagement to support and moderate conversations.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:34am PT.
+
+David Bryant  
+Secretary of the meeting

--- a/TSC/2025/tsc-07-01.md
+++ b/TSC/2025/tsc-07-01.md
@@ -25,7 +25,7 @@ The Alliance Board approved the compliance test development project at its June 
 TSC members shared ideas about improving community participation on the Alliance Zulip chat server, including possible regional discussion groups, server administration changes to handle Code of Conduct concerns, and improved mechanisms for TSC engagement to support and moderate conversations.
 
 ### Adjournment
-There being no other business to come before the meeting, it was adjourned at approximately 12:34am PT.
+There being no other business to come before the meeting, it was adjourned at approximately 12:04pm PT.
 
 David Bryant  
 Secretary of the meeting


### PR DESCRIPTION
Publish minutes for the July 1, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).