### PR TITLE
TSC meeting minutes for July 8, 2025

### DIFF
--- a/TSC/2025/tsc-07-08.md
+++ b/TSC/2025/tsc-07-08.md
@@ -1,0 +1,31 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** July 8, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+David summarized progress made in negotiating a statement of work for the  compliance test development project, soliciting feedback from TSC members on language proposed to handle attribution on behalf of the candidate vendor. TSC members reviewed current Alliance attribution and copyright policies and suggested updating the board regarding this aspect of the pending SOW.
+
+### Topic #3
+Motivated by recent feedback from prospective Recognized Contributors, TSC members revisited the current requirement that RCs must vote in elections to maintain their active status. There was support for removing that requirement, which Till took the action item to frame as a pull request against the TSC charter enabling further review. As charter modifications require board approval, this topic was added to the agenda for the upcoming board meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:42am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the July 8, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).