### PR TITLE
Publish TSC minutes for July 24, 2025

### DIFF
--- a/TSC/2025/tsc-07-24.md
+++ b/TSC/2025/tsc-07-24.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** July 24, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  As an operational note there was no in-person TSC meeting last week given member availability, with TSC business conducted on-line as appropriate.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. The tree-sitter-wit project has been fully approved and on boarded as the Alliance's newest Hosted Project.
+
+### Topic #2
+David provided an update on progress negotiating a suitable Statement of Work for the proposed compliance test development progress. He expects the one remaining issue to be resolved this week, allowing board approval and signature as early as next week.
+
+### Topic #3
+Next week's TSC meeting was canceled due to member conflicts, with members agreeing to maintain relevant topics through the shared working agenda document and resolve issues as needed on-line.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:22am PT.
+
+David Bryant  
+Secretary of the meeting


### PR DESCRIPTION
Publish minutes from the July 24, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).