### PR TITLE
TSC minutes for August 5, 2025

### DIFF
--- a/TSC/2025/tsc-08-05.md
+++ b/TSC/2025/tsc-08-05.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 5, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. The wstd project has been fully approved and on boarded as the Alliance's newest Hosted Project. The WAMR project has distributed information on an upcoming security release to the Alliance security announcement mailing list.
+
+### Topic #2
+The TSC debriefed from the recent CVE retrospective review with the WAMR project team, identifying both actionable feedback for the WAMR project and process improvements for the TSC in documenting and sharing its findings.
+
+### Topic #3
+David informed the TSC that the WASI compliance test development project Statement of Work had been signed by the Alliance and selected vendor. He is scheduling a kick-off meeting for key involved individuals for sometime the week of August 11th, allowing the project to officially begin.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:00pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes from the August 5, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).