### PR TITLE
Publish minutes of TSC meetings

### DIFF
--- a/TSC/2025/tsc-08-12.md
+++ b/TSC/2025/tsc-08-12.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 12, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics.
+
+### Topic #2
+The TSC reviewed and approved a proposed blog post highlighting new support for AArch64in in Wasmtime through a recent update to Winch.
+
+### Topic #3
+David informed the TSC that the WASI compliance test development project was officially underway, having held its kickoff meeting on August 11.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:00pm PT.
+
+David Bryant  
+Secretary for the meeting

--- a/TSC/2025/tsc-wamr-cve-debrief-0626.md
+++ b/TSC/2025/tsc-wamr-cve-debrief-0626.md
@@ -1,0 +1,29 @@
+# WAMR Project Security Advisory Debrief
+
+## Background
+The Bytecode Alliance Technical Steering Committee (TSC) met with members of the WAMR project team on June 26, 2025 as a retrospective on the response to a [security advisory](https://github.com/bytecodealliance/wasm-micro-runtime/security/advisories/GHSA-8fc8-4g25-c8m7) reported on April 14, 2025 and resolved by the project in an update announced on July 31, 2025. The intent of the retrospective was to reflect both on how the team handled the security advisory and how the Bytecode Alliance provides tools and support, especially through the TSC, to projects who need to respond similarly.  This document summarizes those discussions, emphasizing lessons learned and action steps identified both for the WAMR project team and the TSC.
+
+## What Went Well
+* The WAMR project team engaged quickly to scope the vulnerability as a consequence of a vulnerability in an project dependency (uvwasi), and provide a quick fix to WAMR as a workaround
+* Meanwhile, the team worked quickly to create a private fork in which to develop a full fix for the underlying problem
+* The WAMR team reached out directly to the uvwasi team about their interest in resolving the underlying issue, emphasizing the importance to WAMR
+* The WAMR team immediately alerted its customers off the vulnerability and available workaround.
+* The WAMR team made good use of the Wasmtime project's [Advisory Runbook](https://docs.wasmtime.dev/security-vulnerability-runbook.html), using it proactively in working through this issue.
+
+## Lessons Learned and Areas For Improvement
+### For the WAMR Project
+* Communications around a security advisory through the Common Vulnerabilities and Exposures (CVE) system are well established and facilitated through services and features provided to developers, e.g. via GitHub. The team made use of some of those tools and best practices, but missed others and/or mishandled timing. For example, it is important to not share broadly that a vulnerability exists before thiere is a fix or workaround.  It is also important to reach out right away to whomever reported the vulnerability to coordinate any outreach they may undertake (e.g. posting about the advisory on Reddit, as seems to have happened here).
+* At the time the advisory was created in the WAMR project repository, only WAMR core team members were notified. Subsequent changes have been made there to also include TSC and Bytecode Alliance board members so they are notified from the outset as well.
+* Reporting the problem to the uvwasi team via a public GitHub issue made the advisory known publiclaly to all. It would have been better to have opened a security advisory on uvwasi itself (which did happen eventually)
+* Announcement of the vulnerability and resolution should have happened via the Bytecode Alliance Security Announcement mailing list, which is maintained for this purpose and used by other projects. That announcement was handled after the fact.
+* The fix needed to resolve the advisory in WAMR was rolled into a minor release along with a number of other features and changes, and should have been provided in a patch that just contains the fix. This makes it more complicated for the fix to be incorporated by customers and can delay their ability to deploy the fix to their customers. In considering this improvement for the future, some enhancements were identified in the WAMR release process.
+
+### For the Bytecode Alliance and TSC
+* The TSC should review and upate the general Bytecode Alliance [Vulnerability Response Runbook](https://github.com/bytecodealliance/rfcs/blob/main/accepted/vulnerability-response-runbook.md) based on these learnings.
+* The TSC should help provide specialized versions of the Vulnerability Response Runbook for all Alliance projects that have a sandbox. The WAMR team found it useful to refer to the existing Wasmtime [Vulnerability Runbook](https://docs.wasmtime.dev/security-vulnerability-runbook.html), highlighting the benefit of having one for all projects that aim to run untrusted code.
+* The TSC should review release processes for all projects to help share best practices and identify improvementts. In this case, for example, the WAMR project would have benefited from being able release from a branch (as other Alliance projects do).
+* The TSC should work with projects to document as appropriate what constitutes a security vulnerability, as Wasmtime has [done](https://github.com/bytecodealliance/wasmtime/blob/main/docs/security-what-is-considered-a-security-vulnerability.md).
+
+
+
+


### PR DESCRIPTION
Publish minutes from meetings of the Bytecode Alliance Technical Steering Committee (TSC), specifically from the regularly scheduled working meeting held on August 12, 2025 as well as a meeting held on June 26 to debrief with WAMR project team members on work done to resolve a security advisory.