### PR TITLE
August 19, 2025 TSC minutes

### DIFF
--- a/TSC/2025/tsc-08-19.md
+++ b/TSC/2025/tsc-08-19.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 19, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. Members agreed on an approach for publishing notes from topic-specific TSC meetings as an important complement to minutes from these weekly working meetings.
+
+### Topic #2
+Discussion continued from previous TSC meetings regarding improving security handling and disclosure processes for the WAMR project in collaboration with the project team, leveraging insights from their recent CVE resolution experience. A few follow up topics were identified, with actions assigned to bring those topics into the conversation with the team. 
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:00pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the August 19, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).