### PR TITLE
TSC minutes for August 26, 2025

### DIFF
--- a/TSC/2025/tsc-08-26.md
+++ b/TSC/2025/tsc-08-26.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** August 26, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. The TSC discussed an action item received from the Bytecode Alliance board at the most recent board meeting regarding a question of Alliance project governance, in order to provide a response at the next board meeting.
+
+### Topic #2
+Oscar suggested the TSC take a more active role curating informational content related to Bytecode Alliance activities and directions, mentioning several examples he had reached out to knowledgeable authors regarding to explore their interest. There was good support from other TSC members, with a suggestion that time be spent at the next TSC meeting brainstorming content that could be curated by the TSC.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:04pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the August 26, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).