### PR TITLE
TSC minutes for Sep 2, 2025

### DIFF
--- a/TSC/2025/tsc-09-02.md
+++ b/TSC/2025/tsc-09-02.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 2, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. 
+
+### Topic #2
+Oscar and Bailey facilitated a brainstorm of ideas for content topics the TSC could curate to raise awareness of Alliance projects and perspectives. Going forward TSC members will engage with selected authors to facilitate content creation and publication, as well as maintain an active list of desired topics. TSC members will follow up with SIG-Documentation and the Alliance board to make them aware of and involve them in the overall effort.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:02pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the September 2, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).