### PR TITLE
TSC minutes for Sep 9, 2025

### DIFF
--- a/TSC/2025/tsc-09-09.md
+++ b/TSC/2025/tsc-09-09.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 9, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. A new Security Advisory is being handled by the WAMR team.
+
+### Topic #2
+TSC members checked back in on a converged list of informational content to be curated, updating progress on various proposals and suggesting additional topics. The overall list is now being maintained and reviewed as a dashboard, for regular discussion as a standing agenda item.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:04pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the September 9, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).