### PR TITLE
Publish TSC minutes for Sep 16, 2025

### DIFF
--- a/TSC/2025/tsc-09-16.md
+++ b/TSC/2025/tsc-09-16.md
@@ -1,0 +1,35 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 16, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Oscar Spencer  
+Andrew Brown  
+Bailey Hayes  
+Till Schneidereit  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, and ongoing standards efforts within the W3C Community Group. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. The WAMR project published a security release and update announcement. Till suggested as an additional governance-related standing agenda item a summary of topics from the most recent Alliance board meeting, which David will provide going forward.
+
+### Topic #2
+TSC members updated plans for content development efforts and reviewed status of work via the shared dashboard. In doing so there was discussion of the opportunity to highlight that 2025 is the tenth birthday of WebAssembly.
+
+### Topic #3
+TSC members debriefed on a recent advisory meeting with a company that had reached out to the Bytecode Alliance for guidance on adopting WebAssembly in their products, which also further highlighted the benefit of publishing content to raise awareness of WebAssembly advances and community efforts.
+
+### Topic #4
+Till proposed organizing a roadmap and project status planning meeting in the near future, with broad support from other TSC members. The WebAssembly Community Group in-person meeting in late October was highlighted as a good opportunity to do so, presuming project representatives and key contributors would be available or could attend. Members agreed to explore the idea further and review options at next week's TSC meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:10pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the September 16, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).