### PR TITLE
TSC minutes for Sep 23, 2025

### DIFF
--- a/TSC/2025/tsc-09-23.md
+++ b/TSC/2025/tsc-09-23.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 23, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Andrew Brown  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC,  ongoing standards efforts within the W3C Community Group, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. Discussions continue with WAMR project maintainers to arrange a working meeting with the TSC related to project support efforts and security advisories.
+
+### Topic #2
+Planning continues, both offline and through conversation on Zulip, for a roadmap summit working session to be co-located with the late October in-person meeting of the W3C WebAssembly Community Group in Munich. 
+
+### Topic #3
+David highlighted that the compliance testing project underway with a third party is entering its last month of development, offering an opportunity to review progress, suggest adjustments in meeting remaining milestones, and discuss follow-up efforts based on final project deliverables. He will forward the most recent project status report to TSC members for review.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:04pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the September 23, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).