### PR TITLE
TSC minutes for September 30, 2025

### DIFF
--- a/TSC/2025/tsc-09-30.md
+++ b/TSC/2025/tsc-09-30.md
@@ -1,0 +1,33 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** September 30, 2025  
+**Time:** 11:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Till Schneidereit  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC,  ongoing standards efforts within the W3C Community Group, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics. 
+
+### Topic #2
+Planning continues, both offline and through conversation on Zulip, for a roadmap summit working session on Monday, October 27th to be co-located with the in-person meeting of the W3C WebAssembly Community Group in Munich. Attendees are being confirmed and an agenda developed. Options for a meeting location are being explored with organizations in a position to serve as host.  
+
+### Topic #3
+TSC members continued discussion of a possible extension to the ongoing WASI compliance test development project, which will be wrapping up in the next two weeks. Further conversation with the vendor involved will explore possible milestones and deliverables for an extension, allowing a proposal to be shared with the Alliance board for review.
+
+### Topic #4
+Till provided a debrief on a meeting he held recently on behalf of the Wasmtime project with an organization that had approached the Alliance for guidance on their consideration of WebAssembly in their products.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 12:02pm PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the September 30, 2025 meeting of the Bytecode Alliance Technical Steering Committee (TSC).