### PR TITLE
Publish TSC minutes for April 7, 2026

### DIFF
--- a/TSC/2026/tsc-04-07.md
+++ b/TSC/2026/tsc-04-07.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 7, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Christof Petig  
+Till Schneidereit  
+Oscar Spencer  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC,  ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. Project teams continue to actively work on the recently reported Security Advisories, including preparing to announce updates through the appropriate channels.
+
+### Topic #2
+At last week's meeting the Alliance board ratifed nominees for TSC Director and TSC Chair. The Alliance website has been updated to show the new members and office holders.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:52am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the April 7, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).