### PR TITLE
Publish April 14, 2026 TSC minutes

### DIFF
--- a/TSC/2026/tsc-04-14.md
+++ b/TSC/2026/tsc-04-14.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 14, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Christof Petig  
+Till Schneidereit  
+Oscar Spencer  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. A blog post announcing recent Security Advisory response work and highlighting the impact of new audit tools was published on April 9th, with analysis work continuing with impacted projects.
+
+### Topic #2
+Discussed the need to make LLM API keys available for project use, given the benefits and experience of recent security advisory work. Till will raise the topic with the Alliance board at its next meeting.
+
+### Topic #3
+Plans for the WACE 2026 academic workshop have changed due to revised requirements from the hosting conference. Another host event is being sought.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:01am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes from the April 14, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).