### PR TITLE
Publish TSC minutes for April 21, 2026

### DIFF
--- a/TSC/2026/tsc-04-21.md
+++ b/TSC/2026/tsc-04-21.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 21, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Christof Petig  
+Till Schneidereit  
+Oscar Spencer  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. 
+
+### Topic #2
+Till proposed an Alliance policy for AI tool use, reflecting recent Alliance project experience as well as observations from discussions by similar organizations. TSC members reviewed and commented on the proposal, which is available externally as a public PR. An updated version of the proposed policy will be presented for review and approval by the Alliance Board.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:15am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the April 21, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).