### PR TITLE
Publish TSC minutes for April 28, 2026

### DIFF
--- a/TSC/2026/tsc-04-28.md
+++ b/TSC/2026/tsc-04-28.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** April 28, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Christof Petig  
+Till Schneidereit  
+Oscar Spencer  
+Bailey Hayes  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. 
+
+### Topic #2
+The TSC continued its efforts to produce an AI tool use policy, reviewing recent comments on the public draft and proposing revisions based on further discussion. This produced an updated policy document which will receive a final online review pass, allowing TSC approval in time for sharing at this week's Alliance board meeting.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:48am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the April 28, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).