### PR TITLE
docs(sig-guest-languages/go): step down as organizer

### DIFF
--- a/SIG-Guest-Languages/Go/README.md
+++ b/SIG-Guest-Languages/Go/README.md
@@ -17,7 +17,6 @@ Invites are managed by the [Go go-sg@bytecodealliance Google group][google-group
 
 If the above fails, please email:
 
-* Jiaxiao Zhou (jiazho@microsoft.com)
 * Damian Gryski (dgryski@fastly.com)
 
 ## Agendas and Notes


### PR DESCRIPTION
Removing myself (Jiaxiao Zhou) from the organizer list for the Go SIG-Guest-Languages meeting. Damian Gryski remains as the organizer.