### PR TITLE
Publish TSC minutes for May 12, 2026

### DIFF
--- a/TSC/2026/tsc-05-12.md
+++ b/TSC/2026/tsc-05-12.md
@@ -1,0 +1,35 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 12, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Christof Petig  
+Till Schneidereit  
+Bailey Hayes  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. 
+
+### Topic #2
+Till described his recent work developing an augmented approach to GitHub automations using external webhook handlers, proposing the Alliance use it to improve notification of GitHub events. TSC members agreed to move forward with implementation.
+
+### Topic #3
+David, following up on an action item from a previous meeting, shared a document summarzing the current state of Alliance Special Interest Groups for TSC review and identifying a few steps that should be taken to update public information about current SIGs and their operation. He will continue this work and report back at the next TSC meeting.
+
+### Topic #4
+Due to travel and member availability, there will be no in-person TSC meeting on May 19. TSC business will be conducted online and via Zulip.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:56am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the May 12, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).