### PR TITLE
Update Go subgroup meeting details

### DIFF
--- a/SIG-Guest-Languages/Go/README.md
+++ b/SIG-Guest-Languages/Go/README.md
@@ -1,29 +1,11 @@
-# Go SIG Guest Languages Meetings
+# Go SIG Guest Languages Subgroup
 
-A meeting for [the Special Interest Group (SIG) on Guest Languages for Wasm, focusing on Go](https://github.com/bytecodealliance/governance/blob/main/SIGs/SIG-guest-languages/proposal.md).
+ Information and archive for [the Special Interest Group (SIG) on Guest Languages for Wasm, focusing on Go](https://github.com/bytecodealliance/governance/blob/main/SIGs/SIG-guest-languages/proposal.md).
 
-## Time and Location
+## Subgroup Operations
 
-**When**: every other Tuesday at 10am PST (1pm EST)
+The Go language subgroup works together online and does not hold regular meetings. Activities and conversations take place less formally through topics on the Bytecode Alliance Zulip server in the [SIG-Guest-Languages channel](https://bytecodealliance.zulipchat.com/#narrow/channel/394175-SIG-Guest-Languages). If you're interested in use of the Go language with WebAssembly please join us there! You're welcome to post questions or propose new topics and join in the general discussion.
 
-**Where**: Zoom (link in calendar invite)
+## Historical Agendas and Notes
 
-## Attending
-
-Invites are managed by the [Go go-sg@bytecodealliance Google group][google-group] (See also the [BCA calendar][bca-cal]).
-
-[google-group]: https://groups.google.com/a/bytecodealliance.org/g/go-subgroup
-[bca-cal]: https://calendar.google.com/calendar/embed?src=events%40bytecodealliance.org
-
-If the above fails, please email:
-
-* Jiaxiao Zhou (jiazho@microsoft.com)
-* Damian Gryski (dgryski@fastly.com)
-
-## Agendas and Notes
-
-Agendas and notes are posted in this Google [docs](https://docs.google.com/document/d/1gpCjgl5F4SCX21FheIkQRse8hPm15Gxf2us8JkmThoU/edit?tab=t.0#heading=h.mx9ludxxowrs)
-
-## Adding Agenda Items
-
-To add something to the agenda for an upcoming meeting, please comment on the docs above.
+Agenda and notes from past meetings of the Subgroup are gathered here for reference, organized in subfolders by year. 

--- a/SIG-Guest-Languages/Go/README.md
+++ b/SIG-Guest-Languages/Go/README.md
@@ -4,7 +4,7 @@
 
 ## Subgroup Operations
 
-The Go language subgroup works together online and does not hold regular meetings. Activities and conversations take place less formally through topics on the Bytecode Alliance Zulip server in the [SIG-Guest-Languages channel](https://bytecodealliance.zulipchat.com/#narrow/channel/394175-SIG-Guest-Languages). If you're interested in use of the Go language with WebAssembly please join us there! You're welcome to post questions or propose new topics and join in the general discussion.
+The Go language subgroup works together online and does not hold regular meetings. Activities and conversations take place less formally through topics on the Bytecode Alliance Zulip server in the [SIG-Guest-Languages channel](https://bytecodealliance.zulipchat.com/#narrow/channel/394175-SIG-Guest-Languages). If you're interested in use of the Go language with WebAssembly please join us there! You're welcome to post questions, propose new topics and join in the general discussion.
 
 ## Historical Agendas and Notes
 

--- a/SIG-Guest-Languages/README.md
+++ b/SIG-Guest-Languages/README.md
@@ -1,6 +1,6 @@
 # SIG Guest Languages Meetings and Activities
 
-The Bytecode Alliance Special Interest Group (SIG) for Guest Languages fosters community engagement for status updates and discussions on how best to integrate Wasm and components into guest programming language ecosystems in a way that feels native to those ecosystems.
+The Bytecode Alliance Special Interest Group (SIG) for Guest Languages fosters community engagement through meetings and online discussions on how best to integrate Wasm and components into guest programming language ecosystems in a way that feels native to those ecosystems.
 
 Anyone interested is welcome to join.
 

--- a/SIG-Guest-Languages/README.md
+++ b/SIG-Guest-Languages/README.md
@@ -1,8 +1,6 @@
-# SIG Guest Languages Meetings
+# SIG Guest Languages Meetings and Activities
 
-The Bytecode Alliance hosts weekly meetings for status updates and discussions 
-on how best to integrate Wasm and components into guest programming language ecosystems 
-in a way that feels native to those ecosystems.
+The Bytecode Alliance Special Interest Group (SIG) for Guest Languages fosters community engagement for status updates and discussions on how best to integrate Wasm and components into guest programming language ecosystems in a way that feels native to those ecosystems.
 
 Anyone interested is welcome to join.
 
@@ -10,18 +8,22 @@ To receive additional notifications and interact with the community, join the [B
 
 [bca-google-group]: https://groups.google.com/g/ba-sig-guest-languages
 
+
 ## Time and location
 
-SIG Guest Languages does not have a recurring meeting. These may resume when needed,
-but for now the recurring meetings are in the language Subgroups.
+SIG Guest Languages does not have a recurring meeting. These may resume when needed, but for now any recurring meetings are in the language Subgroups.  
 
-**When**: Subgroups have their own meeting schedules
+**When**: Subgroups have their own meeting schedules  
 **Where**: Meeting details (including calendar invites) are accessible through the [Bytecode Alliance shared Calendar][bca-cal]
 
 > [!NOTE]
 > If SIG Guest Languages meetings are not visible on the BCA calendar for you, ensure you have joined the [BCA Guest Languages Google Group][bca-google-group]
 
 [bca-cal]: https://calendar.google.com/calendar/u/0/embed?src=events@bytecodealliance.org
+
+## Join the Discussions on Zulip
+
+A wide variety of active discussions take place in the [SIG-Guest-Languages channel](https://bytecodealliance.zulipchat.com/#narrow/channel/394175-SIG-Guest-Languages) on the Bytecode Alliance Zulip server. Please join us there!
 
 ## Agendas and Notes
 


### PR DESCRIPTION
The Go subgroup of SIG-Guest-Languages is shifting from regular in person meetings to a more casual working model built around discussions on Zulip.  This update adjusts relevant meeting information for the subgroup so interested parties can know how to take part via those online resources rather than by joining a scheduled video meeting. 

Other SIGs and subgroups may find this operating model useful, so the changes made here were done with the idea they may be reused elsewhere.