### PR TITLE
Publish May 26, 2026 TSC minutes

### DIFF
--- a/TSC/2026/tsc-05-26.md
+++ b/TSC/2026/tsc-05-26.md
@@ -1,0 +1,32 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** May 26, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Christof Petig  
+Till Schneidereit  
+Bailey Hayes  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.  As a note, there was no in-person TSC meeting on May 19 due to member travel and limited availability.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. Endive has been announced as the Bytecode Alliance's newest Hosted Project, with an introductory post on the Alliance blog.
+
+### Topic #2
+The TSC discussed progress and status of registry-related efforts, with reference to an established general registry specification and user stories for the Alliance as well as the current state of registry efforts across the industry.
+
+### Topic #3
+David provided an update on operational topics. An academic workshop proposal has been submitted to a December 2026 ACM conference for consideration. Modifications to SIG governance are being considered to clarify more informal operations through online discussion as an alternative to in-person meetings.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:07am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the May 26, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).