### PR TITLE
Publish TSC minutes for June 2, 2026

### DIFF
--- a/TSC/2026/tsc-06-02.md
+++ b/TSC/2026/tsc-06-02.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** Jun 2, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Till Schneidereit  
+Bailey Hayes  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. Till provided an update on options for managing Copilot integration with Alliance GitHub repositories.
+
+### Topic #2
+David provided an update on operational topics. Our proposed academic workshop has been accepted as part of the ACM Middleware 2026 conference in December, with our call for papers to go out by June 18. Less formal SIG operations have been put in place for the Go subgroup of SIG-Guest-Languages per their request, with other SIGs to be updated should they be interested as well.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:45am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the June 2, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).