### PR TITLE
Publish TSC minutes for June 30, 2026

### DIFF
--- a/TSC/2026/tsc-06-30.md
+++ b/TSC/2026/tsc-06-30.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** Jun 30, 2026  
+**Time:** 10:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Christof Petig  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon. There was no in-person TSC meeting on June 16 due to member travel and limited availability, with business conducted online.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, recognition of project maintainers, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. 
+
+### Topic #2
+David provided an update on operational topics. Endive 1.0 has been launched, including with an announcement on BA Zulip.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:40am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the June 30, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).