### PR TITLE
TSC minutes for July 7, 2026

### DIFF
--- a/TSC/2026/tsc-07-07.md
+++ b/TSC/2026/tsc-07-07.md
@@ -1,0 +1,30 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** Jul 7, 2026  
+**Time:** 9:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Christof Petig  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+Conrad Watt  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+Conrad Watt, co-chair of the W3C WebAssembly Community Group (CG), joined for a conversation with the TSC about topics of mutual interest, including status of CG activities, plans for standardization progress in the second half of 2026, agenda for the August in-person CG meeting, and current TSC governance efforts.
+
+### Topic #2
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, recognition of project maintainers, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting. 
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:54am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes for the July 7, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).