### PR TITLE
Publish July 14, 2026 TSC minutes

### DIFF
--- a/TSC/2026/tsc-07-14.md
+++ b/TSC/2026/tsc-07-14.md
@@ -1,0 +1,29 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** Jul 14, 2026  
+**Time:** 9:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Christof Petig  
+Oscar Spencer  
+
+**Others present:**  
+David Bryant  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, recognition of project maintainers, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting
+
+### Topic #2
+Till proposed formalizing the existing Component Model Implementation working group as a Bytecode Alliance Special Interest Group (SIG). After discussing the benefits of such a change, how it would most easily be accomplished given the group's current operating model, and appropriate name and scope for the effort as a SIG, Till received support for discussing the plan with working group members and moving ahead in proposing the change publicly via the BA governance repository.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:40am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish minutes from the July 14, 2026 meeting of the Bytecode Alliance Technical Steering Committee (TSC).