### PR TITLE
Cranelift 2026-08-12: move deferred agenda item.

### DIFF
--- a/cranelift/2026/cranelift-07-29.md
+++ b/cranelift/2026/cranelift-07-29.md
@@ -12,7 +12,6 @@
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
     1. fitzgen: sightglass and PCA presentation
-    1. cfallin: instruction selection/fusion for add-with-overflow + branch
     1. _Submit a PR to add your item here_
 
 ## Notes

--- a/cranelift/2026/cranelift-08-12.md
+++ b/cranelift/2026/cranelift-08-12.md
@@ -11,6 +11,7 @@
 1. Announcements
     1. _Submit a PR to add your announcement here_
 1. Other agenda items
+    1. cfallin: instruction selection/fusion for add-with-overflow + branch
     1. _Submit a PR to add your item here_
 
 ## Notes


### PR DESCRIPTION
This item was initially planned several weeks ago, pushed to this morning's meeting, then we ran out of time again; hopefully we'll get to it first thing on August 12!