### PR TITLE
Tsc update

### DIFF
--- a/TSC/2026/tsc-08-25.md
+++ b/TSC/2026/tsc-08-25.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** Aug 25, 2026  
+**Time:** 9:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Till Schneidereit  
+Oscar Spencer  
+
+**Others present:**  
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon. As a note, there were no in-person TSC meetings on August 4, 11, and 18 due to overlap with the W3C Community Group in-person meeting as well, member travel and availability, and handling of topics off-line.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, recognition of project maintainers, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Maintenance status of current projects was reviewed as a topic of recurring interest. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting.
+
+### Topic #2
+TSC members discussed possibilities for hosting the next Plumbers Summit event, including desired timing and candidate locations as an in-person gathering.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 11:00am PT.
+
+David Bryant  
+Secretary for the meeting

--- a/TSC/2026/tsc-09-01.md
+++ b/TSC/2026/tsc-09-01.md
@@ -1,0 +1,28 @@
+# Meeting Minutes
+## Bytecode Alliance Technical Steering Committee
+**Date:** Sep 1, 2026  
+**Time:** 9:00am PT  
+**Place:** By online video conference  
+
+**TSC Members present:**  
+Bailey Hayes  
+Christof Petig  
+Oscar Spencer  
+
+**Others present:**  
+None  
+
+### Agenda
+The TSC reviewed the agenda for the meeting and a final agenda was agreed upon.
+
+### Topic #1
+The TSC reviewed current governance topics as identified across issues and pull requests in the Alliance governance and project repositories, recognition of project maintainers, consideration of projects for Hosted or Core Project status, Special Interest Group activities, nominations for Recognized Contributor, communications received by the TSC, ongoing standards efforts within the W3C Community Group, topics of broad scope in the Alliance's Zulip community, and a recap of the most recent Alliance board meeting. Proper follow-up actions will be taken by reviewers on the requests and issues discussed, including scheduling meetings needed to advance active topics and providing an update at the next Alliance board meeting.
+
+### Topic #2
+David provided an update on several operational topics, including a reminder that the upcoming election cycle would include filling three Elected Delegate seats on the TSC and one At-Large Director seat on the Alliance board.
+
+### Adjournment
+There being no other business to come before the meeting, it was adjourned at approximately 10:47am PT.
+
+David Bryant  
+Secretary for the meeting


### PR DESCRIPTION
Publish meeting minutes for the August 25, 2026 and September 1, 2026 meetings of the Bytecode Alliance Technical Steering Committee (TSC).